### PR TITLE
Add OpenAI Responses API adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- `/v1/chat/completions` protocol adapter over the existing Anthropic `ParsedMessages` run engine. Contract-tested text, OpenAI SSE, function tools, continuation, replay, deferred and cache-aware usage, images, and OpenAI error shapes. `/v1/responses` is not implemented.
+- `/v1/chat/completions` protocol adapter over the existing Anthropic `ParsedMessages` run engine. Contract-tested text, OpenAI SSE, function tools, continuation, replay, deferred and cache-aware usage, images, and OpenAI error shapes.
+- `/v1/responses` protocol adapter over the same run engine. Contract-tested non-stream text, Responses SSE lifecycle, reasoning, base64 `input_image`, function tools, same-turn parallel calls, `function_call_output` continuation by `call_id`, duplicate-same replay, deferred/final cache-aware usage, `reasoning_effort` / `cursor_model_params`, and Responses-shaped errors. `previous_response_id`, `store=true`, background, conversation, include expansions, and hosted built-in tools fail closed. Operator Console playground stays Messages/Chat.
 - Optional BF Labs Operator Console at `/console/`, bundled as static Vite assets and served by the existing Node process. It includes health, model/account reads, Messages/Chat playground, connection snippets, English/Chinese, and light/dark modes. Keys remain in page memory only.
 
 ## 0.1.0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Independent MIT gateway that exposes the official Cursor TypeScript SDK (`@curso
 
 This is **not** an official Cursor or Anysphere product. It does not reverse private Cursor transports, cookies, Desktop/CLI stores, or IDE sessions. The only Cursor execution engine is the published `@cursor/sdk` package. Users must supply a legally obtained Cursor API key and comply with Cursor Terms of Service.
 
-**v0.1 is Anthropic Messages-first.** `/v1/chat/completions` is implemented as a protocol adapter over that same run engine (contract-tested, not live-model certified). `/v1/responses` is not implemented.
+**v0.1 is Anthropic Messages-first.** `/v1/chat/completions` and `/v1/responses` are protocol adapters over that same run engine (contract-tested, not live-model certified).
 
 ## What v0.1 includes
 
@@ -18,6 +18,7 @@ This is **not** an official Cursor or Anysphere product. It does not reverse pri
 | `GET` | `/v1/account` | required | Identity from `Cursor.me()`. Spending and limits appear only when the official surface returns them. |
 | `POST` | `/v1/messages` | required | Anthropic Messages text, SSE, client tools, same-turn parallel tools, multi-round continuation, and in-process replay. |
 | `POST` | `/v1/chat/completions` | required | OpenAI Chat Completions adapter: text, `data:` SSE + `[DONE]`, function tools, continuation, `reasoning_content`, base64 `image_url`. Same session/run engine as Messages. |
+| `POST` | `/v1/responses` | required | OpenAI Responses adapter: `input` string or items, Responses SSE + `response.completed`, reasoning, base64 `input_image`, `type=function` tools, `function_call_output` continuation by `call_id`. Same session/run engine as Messages. `previous_response_id` / hosted tools / `store=true` fail closed. Console playground stays Messages/Chat. |
 
 Default **API Compatibility Profile**:
 
@@ -124,6 +125,19 @@ curl -s localhost:8080/v1/chat/completions \
 
 `n` must be `1` or omitted. Remote `image_url` URLs are rejected (`422`); send a base64 data URL. Stream frames are OpenAI `data:` chunks with a blank line after each frame (no Anthropic event names) and end with `data: [DONE]`. `stream_options.include_usage=true` adds a `choices=[]` usage chunk before `[DONE]`.
 
+`/v1/responses` uses the same run engine. Completed follow-up still takes `x-cursor-session-id`. Pending tools resume only when the latest `input` items are `function_call_output` and `call_id` matches the live tool id. `previous_response_id` is rejected; this is not a stateless OpenAI store.
+
+```bash
+curl -s localhost:8080/v1/responses \
+  -H "Authorization: Bearer $CURSOR_API_KEY" \
+  -H "content-type: application/json" \
+  -d '{"model":"composer-2.5","input":"hello"}'
+```
+
+Stream events use Responses names (`response.created` … `response.completed`). On error the stream emits a Responses `error` event and does not emit `response.completed`. Hosted tools, `store=true`, background, conversation, and include expansions fail closed.
+
+`function_call_output.output` accepts a string or an array of text content parts. Image/file tool-output parts fail closed with `422` until they can be mapped to the SDK without semantic loss.
+
 Keep the public catalog model ID unchanged. For Grok 4.6 xhigh:
 
 ```json
@@ -158,7 +172,7 @@ Tool continuation uses the same process-local Agent/Run. The latest user turn mu
 }
 ```
 
-For `/v1/messages`, `max_tokens` is accepted so Claude Code-shaped requests parse. The SDK harness has no precise max-token enforcement, and the gateway does not emulate one. `temperature`, `top_p`, `stop_sequences`, and `tool_choice` are accepted but **not mapped** to `@cursor/sdk`. For `/v1/chat/completions`, `tool_choice` must be `auto` or omitted; other values fail closed with `422`.
+For `/v1/messages`, `max_tokens` is accepted so Claude Code-shaped requests parse. The SDK harness has no precise max-token enforcement, and the gateway does not emulate one. `temperature`, `top_p`, `stop_sequences`, and `tool_choice` are accepted but **not mapped** to `@cursor/sdk`. For `/v1/chat/completions` and `/v1/responses`, `tool_choice` must be `auto` or omitted; other values fail closed with `422`.
 
 Errors:
 
@@ -217,7 +231,7 @@ Development defaults: 4 global active runs, 2 per credential, 30 minute session 
 
 ## Status and evidence
 
-v0.1 implements Messages text/SSE, client customTools/MCP, same-turn parallel tools, multi-round continuation, in-process replay, tenant/model isolation, completed Agent resume, and fail-closed pending restart. Chat Completions is a contract-tested protocol adapter on that engine. It is not a live-model acceptance claim.
+v0.1 implements Messages text/SSE, client customTools/MCP, same-turn parallel tools, multi-round continuation, in-process replay, tenant/model isolation, completed Agent resume, and fail-closed pending restart. Chat Completions and Responses are contract-tested protocol adapters on that engine. They are not live-model acceptance claims. The Operator Console playground stays on Messages/Chat; Responses is exercised through `/v1/responses` contract tests, not the console UI.
 
 A sanitized, non-secret acceptance summary is in [`docs/evidence/2026-08-15-live-smoke.md`](docs/evidence/2026-08-15-live-smoke.md). That receipt is a dated local sample, not a guarantee for every credential, region, or image:
 
@@ -239,7 +253,7 @@ Thinking and image blocks are implemented and contract-tested. Live thinking/ima
 
 Not implemented:
 
-- OpenAI Responses (`/v1/responses`)
+- Responses `previous_response_id` reconstruction, `store=true`, background mode, conversation objects, include expansions, or hosted built-in tools (`web_search`, `file_search`, `computer`, `shell`, `apply_patch`)
 - Cursor Agent Profile (`/v1/agents`, native shell/edit, plan mode)
 - distributed session ownership / Redis / Postgres
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 
 这不是 Cursor / Anysphere 官方产品。它不逆向私有 Cursor 传输、Cookie、Desktop/CLI 凭据库或 IDE 会话。唯一的 Cursor 执行引擎是公开发布的 `@cursor/sdk`。使用者必须提供合法获得的 Cursor API Key，并遵守 Cursor 服务条款。
 
-**v0.1 以 Anthropic Messages 为先。** `/v1/chat/completions` 是同一套 Run 引擎上的协议适配层（已有 contract 测试，不是真实模型验收声明）。`/v1/responses` 尚未实现。
+**v0.1 以 Anthropic Messages 为先。** `/v1/chat/completions` 和 `/v1/responses` 都是同一套 Run 引擎上的协议适配层（已有 contract 测试，不是真实模型验收声明）。
 
 ## v0.1 包含什么
 
@@ -18,6 +18,7 @@
 | `GET` | `/v1/account` | 需要 | 身份来自 `Cursor.me()`。花费和额度字段仅在官方接口真正返回时出现。 |
 | `POST` | `/v1/messages` | 需要 | Anthropic Messages 文本、SSE、客户端工具、同轮并行工具、多轮 continuation，以及进程内 replay。 |
 | `POST` | `/v1/chat/completions` | 需要 | OpenAI Chat Completions 适配：文本、`data:` SSE + `[DONE]`、function tools、continuation、`reasoning_content`、base64 `image_url`。与 Messages 共用同一套 session/run 引擎。 |
+| `POST` | `/v1/responses` | 需要 | OpenAI Responses 适配：`input` 字符串或 item、Responses SSE + `response.completed`、reasoning、base64 `input_image`、`type=function` 工具、按 `call_id` 续轮 `function_call_output`。与 Messages 共用同一套 session/run 引擎。`previous_response_id` / 托管工具 / `store=true` 会 fail closed。控制台 playground 仍只有 Messages/Chat。 |
 
 默认 **API Compatibility Profile**：
 
@@ -123,6 +124,19 @@ curl -s localhost:8080/v1/chat/completions \
 
 `n` 只能是 `1` 或省略。远程 `image_url` 会被 `422` 拒绝，需要 base64 data URL。流式帧是 OpenAI `data:` chunk（每帧后空一行，没有 Anthropic event 名），并以 `data: [DONE]` 结束。`stream_options.include_usage=true` 会在 `[DONE]` 前多发一个 `choices=[]` 的 usage chunk。
 
+`/v1/responses` 使用同一套 Run 引擎。已完成 follow-up 仍走 `x-cursor-session-id`。pending 工具续轮只接受最新 `input` 全是 `function_call_output`，并且 `call_id` 对上当前 live tool id。`previous_response_id` 会被拒绝；这不是无状态的 OpenAI store。
+
+```bash
+curl -s localhost:8080/v1/responses \
+  -H "Authorization: Bearer $CURSOR_API_KEY" \
+  -H "content-type: application/json" \
+  -d '{"model":"composer-2.5","input":"hello"}'
+```
+
+流式事件使用 Responses 事件名（`response.created` … `response.completed`）。出错时发 Responses `error` 事件，不会发假的 `response.completed`。托管工具、`store=true`、background、conversation 和 include 展开会 fail closed。
+
+`function_call_output.output` 接受字符串或文本 content part 数组。图片/文件型工具结果在能够无损映射到 SDK 前会以 `422` fail closed，不会静默转成 JSON 文本。
+
 保持公开目录中的模型 ID 不变。例如 Grok 4.6 xhigh：
 
 ```json
@@ -157,7 +171,7 @@ curl -s localhost:8080/v1/chat/completions \
 }
 ```
 
-对于 `/v1/messages`，`max_tokens` 会被接受，以便 Claude Code 形态的请求能解析。SDK Harness 没有精确的 max-token 强制执行，网关也不会模拟一层。`temperature`、`top_p`、`stop_sequences` 和 `tool_choice` 会被接受，但 **不会映射** 到 `@cursor/sdk`。对于 `/v1/chat/completions`，`tool_choice` 只能是 `auto` 或省略；其他值会以 `422` fail closed。
+对于 `/v1/messages`，`max_tokens` 会被接受，以便 Claude Code 形态的请求能解析。SDK Harness 没有精确的 max-token 强制执行，网关也不会模拟一层。`temperature`、`top_p`、`stop_sequences` 和 `tool_choice` 会被接受，但 **不会映射** 到 `@cursor/sdk`。对于 `/v1/chat/completions` 和 `/v1/responses`，`tool_choice` 只能是 `auto` 或省略；其他值会以 `422` fail closed。
 
 错误体：
 
@@ -216,7 +230,7 @@ BYOK 凭据共享进程容量上限，但官方 SDK store 和空 workspace 按 c
 
 ## 现状与证据
 
-v0.1 已实现 Messages 文本/SSE、客户端 customTools/MCP、同轮并行工具、多轮 continuation、进程内 replay、租户/模型隔离、completed Agent resume，以及 pending 重启 fail closed。Chat Completions 是这套引擎上的协议适配，已有 contract 测试，不是真实模型验收声明。
+v0.1 已实现 Messages 文本/SSE、客户端 customTools/MCP、同轮并行工具、多轮 continuation、进程内 replay、租户/模型隔离、completed Agent resume，以及 pending 重启 fail closed。Chat Completions 和 Responses 是这套引擎上的协议适配，已有 contract 测试，不是真实模型验收声明。运维控制台 playground 仍只覆盖 Messages/Chat；Responses 通过 `/v1/responses` 的 contract 测试验收，不走控制台 UI。
 
 脱敏、不含秘密的验收摘要见 [`docs/evidence/2026-08-15-live-smoke.md`](docs/evidence/2026-08-15-live-smoke.md)。这份 receipt 是有日期的本地样本，不能保证每个凭据、地区或镜像都一样：
 
@@ -238,7 +252,7 @@ thinking 和 image 块已实现并有 contract 测试。真实模型上的 think
 
 尚未实现：
 
-- OpenAI Responses（`/v1/responses`）
+- Responses 的 `previous_response_id` 重建、`store=true`、background、conversation、include 展开，以及托管内置工具（`web_search`、`file_search`、`computer`、`shell`、`apply_patch`）
 - Cursor Agent Profile（`/v1/agents`、原生 shell/edit、plan mode）
 - 分布式 session 归属 / Redis / Postgres
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,17 +5,19 @@
 One live SDK Run has one owner process and one event-pump consumer.
 
 ```
-HTTP /v1/messages | /v1/chat/completions
-  -> protocol parse (Chat converts to canonical ParsedMessages)
+HTTP /v1/messages | /v1/chat/completions | /v1/responses
+  -> protocol parse (Chat/Responses convert to canonical ParsedMessages)
   -> RunCoordinator
        -> SessionRegistry (fingerprint, model, tool_use_id, TTL)
        -> ToolBridge (request tools -> local.customTools)
        -> EventPump (single run.stream() consumer for tool/status/terminal)
-       -> protocol writer seam (Anthropic SSE or OpenAI data chunks)
+       -> protocol writer seam (Anthropic SSE, OpenAI Chat data chunks, or Responses events)
        -> SdkRuntime (injected; production adapter wraps @cursor/sdk)
 ```
 
-`/v1/chat/completions` does not own a second session or continuation engine. It reuses the same RunCoordinator, pending-tool Map, replay, and identity binding. Only the request parser and HTTP writer differ. `/v1/responses` is not implemented.
+`/v1/chat/completions` and `/v1/responses` do not own a second session or continuation engine. They reuse the same RunCoordinator, pending-tool Map, replay, and identity binding. Only the request parser and HTTP writer differ.
+
+Responses continuation is not `previous_response_id` reconstruction. Pending tool turns resume when the latest input items are only `function_call_output` and `call_id` matches the live `tool_use_id`. Completed follow-up still uses `x-cursor-session-id` exactly as Messages/Chat. `previous_response_id`, `store=true`, background, conversation, include expansions, and hosted built-in tools fail closed.
 
 Text/thinking streaming uses official `SendOptions.onDelta` (`text-delta` / `thinking-delta`). Early deltas that arrive before `send()` resolves are buffered, then ingested into the pump. When onDelta is active, `run.stream()` assistant/thinking snapshots are not forwarded again.
 

--- a/docs/DELIVERY_PLAN.md
+++ b/docs/DELIVERY_PLAN.md
@@ -143,6 +143,8 @@ Claude Code / OpenCode / Codex / SDK / curl
 | `GET /v1/models` | required | live Cursor catalog with stable public model IDs and exposed params |
 | `GET /v1/account` | required | authenticated identity plus capability-based spending/limit fields |
 | `POST /v1/messages` | required | Anthropic-compatible stream and non-stream text/tool contract |
+| `POST /v1/chat/completions` | required | OpenAI Chat adapter over the same Messages run engine |
+| `POST /v1/responses` | required | OpenAI Responses adapter over the same Messages run engine. Tool continuation is `function_call_output.call_id`; completed follow-up is `x-cursor-session-id`. `previous_response_id` is rejected. |
 
 ### 7.2 Health Shape
 
@@ -157,6 +159,8 @@ Health returns at least:
   "runtime": "local",
   "capabilities": {
     "messages": true,
+    "chat_completions": true,
+    "responses": true,
     "streaming": true,
     "thinking": true,
     "images": true,
@@ -546,8 +550,8 @@ Gate:
 | Hard restart behavior is explicit | real-smoke | kill/restart pending tool test | passed-live | All four required models returned `cursor_session_lost`, never empty success |
 | Docker image starts independently | local | Docker build/run, HEALTHCHECK and health readback | passed-local | Clean-checkout rebuild remains a release gate; no external bind mount |
 | Claude Code Fable 5 passes | real-smoke | isolated real client transcript receipt | passed-live | No raw prompts/tool results retained |
-| OpenAI Chat compatibility passes | real-smoke | v0.2 client matrix | pending | Not a v0.1 release gate |
-| OpenAI Responses compatibility passes | real-smoke | v0.2 Codex/OpenCode matrix | pending | Not a v0.1 release gate |
+| OpenAI Chat compatibility passes | real-smoke | v0.2 client matrix | pending | Local Chat contract suite exists; live Chat matrix is not claimed |
+| OpenAI Responses compatibility passes | real-smoke | v0.2 Codex/OpenCode matrix | pending | Local Responses contract suite exists; live Codex/OpenCode is not claimed and is not substituted by curl fixtures |
 | new-api optional channel passes upstream checks | dev | upstream targeted/full tests and PR review | pending | Phase 4 only |
 
 ## 19. Live Model Matrix
@@ -671,6 +675,6 @@ Each step must extend the same vertical path; do not build OpenAI translators be
 
 ## 25. Current Delivery Gate
 
-截至 2026-08-15，Sonnet 4.6 与 Fable 5 已通过宿主机完整 18-case 验收，包含并行工具、缓存读写、completed resume 和 Fable Claude Code shape；Node 22 不可变镜像已用成功/死代理对照证明 Agent 与 fetch 两条 SDK 数据通路均受代理控制，并完成真实 Claude 文本与工具调用。Fable 容器 parallel/upstream 仍有非确定性，因此没有被包装成全绿容器矩阵。Composer 2.5 已通过完整 v0.1 live matrix；Grok 4.6 xhigh 除同轮 parallel 选择可重复性外均通过。下一道模型技术 gate 是定义 parallel repeatability threshold；npm/GHCR 发布、生产部署和 upstream PR 仍是独立后续步骤。
+截至 2026-08-15，Sonnet 4.6 与 Fable 5 已通过宿主机完整 18-case 验收，包含并行工具、缓存读写、completed resume 和 Fable Claude Code shape；Node 22 不可变镜像已用成功/死代理对照证明 Agent 与 fetch 两条 SDK 数据通路均受代理控制，并完成真实 Claude 文本与工具调用。Fable 容器 parallel/upstream 仍有非确定性，因此没有被包装成全绿容器矩阵。Composer 2.5 已通过完整 v0.1 live matrix；Grok 4.6 xhigh 除同轮 parallel 选择可重复性外均通过。`/v1/responses` 已有本地 contract 测试（文本、SSE 生命周期、reasoning、图片、function tools、并行、`function_call_output` 续轮、replay、usage、fail-closed 错误），不是 Codex/OpenCode live smoke。下一道模型技术 gate 是定义 parallel repeatability threshold；npm/GHCR 发布、生产部署和 upstream PR 仍是独立后续步骤。
 
 协议范围、credential modes、默认工具权限、公开许可、repository ownership 或 release path 的实质变化，应在本路线图中明确记录。

--- a/docs/PROTOCOL_COMPATIBILITY.md
+++ b/docs/PROTOCOL_COMPATIBILITY.md
@@ -19,14 +19,27 @@ Canonical internal contract is Anthropic Messages.
 | `/v1/models` | yes | Exact catalog ids or honest empty |
 | `/v1/account` | partial | No fabricated spending |
 | `/v1/chat/completions` | yes | Protocol adapter over the same Messages run engine. Contract-tested: non-stream text, OpenAI SSE `data:` chunks + `[DONE]`, `reasoning_content`, function tools, single/parallel continuation, duplicate-same replay, deferred/final cache-aware usage, `stream_options.include_usage`, `reasoning_effort` / `cursor_model_params`, base64 `image_url`, `n=1` only, unknown tool IDs fail closed, and OpenAI error shapes before and after stream start. Remote `image_url` URLs are `422`. Live Chat model matrix is not claimed. |
-| `/v1/responses` | no | Not implemented |
+| `/v1/responses` | yes | Protocol adapter over the same Messages run engine. Contract-tested: non-stream text; Responses SSE lifecycle (`response.created` → deltas → `response.completed`); reasoning summary events; base64 `input_image`; `tools` `type=function`; same-turn parallel `function_call` items; `function_call_output` continuation by `call_id`; duplicate-same replay without a second resolve; deferred/final cache-aware usage; `reasoning`/`reasoning_effort` / `cursor_model_params`; unknown/mixed/missing `call_id` fail closed; OpenAI REST errors before stream start and a Responses `error` event (no `response.completed`) after stream start. Tool outputs accept a string or text-content array; image/file tool-output parts are `422` until native SDK mapping is implemented. `previous_response_id`, `store=true`, background, conversation, include expansions, remote image URLs, and hosted tools fail closed. Live Codex/OpenCode matrix is not claimed. Operator Console playground stays Messages/Chat by design. |
 | `max_tokens` | accepted | Anthropic-required field is parsed/accepted so Claude Code requests work. The SDK Harness has no precise max-token enforcement; the gateway does not emulate one. |
 | `temperature` / `top_p` / `stop_sequences` | advisory / unsupported | Accepted but **not mapped** to `@cursor/sdk`. v0.1 does not claim equivalent sampling behavior. |
-| `tool_choice` | protocol-specific | Messages accepts but does not map it. Chat allows only `auto` or omission; `required`, `none`, and named-function forms fail closed with `422`. |
+| `tool_choice` | protocol-specific | Messages accepts but does not map it. Chat and Responses allow only `auto` or omission; `required`, `none`, and named-function forms fail closed with `422`. |
 | `reasoning_effort` | extension | Preserves the public model ID and maps the value to the official SDK `effort` model parameter. The live matrix uses `grok-4.6` plus `reasoning_effort: "xhigh"`; it does not invent an alias model name. |
 | `cursor_model_params` | extension | Exact validated `{id,value}` pairs passed to the official SDK model selection. Explicit parameters are bound to the session and persisted for completed `Agent.resume`; an explicit change on the same session is `409 cursor_session_conflict`. |
 
 Completed follow-up and persisted `Agent.resume` consume the same global / per-credential active-run limits as `create`. Awaiting `tool_result` continuation does not.
+
+## Responses continuation identity
+
+The gateway does not implement OpenAI `previous_response_id` reconstruction, `store=true`, or conversation objects. Identity stays the existing Messages engine:
+
+| Client action | How this gateway resumes | What is not a session key |
+|---|---|---|
+| Pending tool turn | Latest `input` items must be only `function_call_output`. Each `call_id` is the live `tool_use_id`. | `previous_response_id`, response `id`, output item `id` |
+| Same outputs again | Request/result digest replay. No second `resolve`. | A new Agent/Run |
+| Completed follow-up | `x-cursor-session-id` on a new `input` that is not a tool-output suffix, same credential/model/params | `previous_response_id` |
+| After process restart, still awaiting tools | `409 cursor_session_lost` | Replaying historical `function_call` items |
+
+`function_call_output` mixed with a later user/message item is `422`. Missing required `call_id`s, unknown ids, and mixed-session ids fail closed the same way as Messages `tool_result`.
 
 Live catalog/text/tool/restart matrix is an opt-in runner (`npm run live:smoke`), not default CI. Catalog-missing required model names fail closed; they are not green skips. This file does not record live model results.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,7 @@ export interface GatewayConfig {
 export interface RuntimeCapabilities {
   messages: boolean;
   chat_completions: boolean;
+  responses: boolean;
   streaming: boolean;
   thinking: boolean;
   images: boolean;
@@ -55,6 +56,7 @@ export interface RuntimeCapabilities {
 export const DEFAULT_CAPABILITIES: RuntimeCapabilities = {
   messages: true,
   chat_completions: true,
+  responses: true,
   streaming: true,
   thinking: true,
   images: true,

--- a/src/ids.ts
+++ b/src/ids.ts
@@ -14,6 +14,12 @@ export function chatCompletionId(fromMessageId?: string): string {
   return `chatcmpl_${randomUUID()}`;
 }
 
+export function responseId(fromMessageId?: string): string {
+  if (fromMessageId?.startsWith("msg_")) return `resp_${fromMessageId.slice(4)}`;
+  if (fromMessageId?.startsWith("resp_")) return fromMessageId;
+  return `resp_${randomUUID()}`;
+}
+
 export function sessionId(): string {
   return `ses_${randomUUID()}`;
 }

--- a/src/protocols/openai-responses/encode.ts
+++ b/src/protocols/openai-responses/encode.ts
@@ -1,0 +1,146 @@
+import { responseId } from "../../ids.js";
+import type { AnthropicContentBlock, AssistantTurn } from "../anthropic/types.js";
+import type { ResponsesStatus } from "./types.js";
+
+export interface ResponsesUsage {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  input_tokens_details?: { cached_tokens: number };
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+  usage_deferred?: boolean;
+  usage_status?: "sdk" | "unavailable" | "deferred";
+}
+
+export function encodeResponsesUsage(turn: AssistantTurn): ResponsesUsage {
+  const usage: ResponsesUsage = {
+    input_tokens: turn.usage.input_tokens,
+    output_tokens: turn.usage.output_tokens,
+    total_tokens: turn.usage.input_tokens + turn.usage.output_tokens,
+  };
+  if (typeof turn.usage.cache_read_input_tokens === "number") {
+    usage.cache_read_input_tokens = turn.usage.cache_read_input_tokens;
+    usage.input_tokens_details = { cached_tokens: turn.usage.cache_read_input_tokens };
+  }
+  if (typeof turn.usage.cache_creation_input_tokens === "number") {
+    usage.cache_creation_input_tokens = turn.usage.cache_creation_input_tokens;
+  }
+  if (turn.usage.usage_deferred) usage.usage_deferred = true;
+  if (turn.usage.usage_status) usage.usage_status = turn.usage.usage_status;
+  return usage;
+}
+
+export function mapResponseStatus(stopReason: AssistantTurn["stopReason"]): {
+  status: ResponsesStatus;
+  incomplete_details: { reason: string } | null;
+} {
+  if (stopReason === "max_tokens") {
+    return { status: "incomplete", incomplete_details: { reason: "max_output_tokens" } };
+  }
+  return { status: "completed", incomplete_details: null };
+}
+
+export function reasoningItemId(messageId: string): string {
+  if (messageId.startsWith("msg_")) return `rs_${messageId.slice(4)}`;
+  if (messageId.startsWith("resp_")) return `rs_${messageId.slice(5)}`;
+  return `rs_${messageId}`;
+}
+
+export function functionCallItemId(callId: string): string {
+  return callId.startsWith("fc_") ? callId : `fc_${callId}`;
+}
+
+export function encodeReasoningItem(messageId: string, text: string): Record<string, unknown> {
+  return {
+    id: reasoningItemId(messageId),
+    type: "reasoning",
+    summary: text ? [{ type: "summary_text", text }] : [],
+  };
+}
+
+export function encodeMessageItem(messageId: string, text: string, status = "completed"): Record<string, unknown> {
+  return {
+    id: messageId,
+    type: "message",
+    status,
+    role: "assistant",
+    content: text
+      ? [{ type: "output_text", text, annotations: [] }]
+      : [],
+  };
+}
+
+export function encodeFunctionCallItem(
+  block: Extract<AnthropicContentBlock, { type: "tool_use" }>,
+  status = "completed",
+): Record<string, unknown> {
+  return {
+    id: functionCallItemId(block.id),
+    type: "function_call",
+    status,
+    call_id: block.id,
+    name: block.name,
+    arguments: JSON.stringify(block.input ?? {}),
+  };
+}
+
+export function encodeResponsesOutput(turn: AssistantTurn): Record<string, unknown>[] {
+  const output: Record<string, unknown>[] = [];
+  const thinking = textOf(turn.blocks, "thinking");
+  if (thinking) output.push(encodeReasoningItem(turn.messageId, thinking));
+  const text = textOf(turn.blocks, "text");
+  if (text) output.push(encodeMessageItem(turn.messageId, text));
+  for (const block of turn.blocks) {
+    if (block.type === "tool_use") output.push(encodeFunctionCallItem(block));
+  }
+  return output;
+}
+
+export function encodeResponse(
+  turn: AssistantTurn,
+  createdAt: number,
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  const { status, incomplete_details } = mapResponseStatus(turn.stopReason);
+  return {
+    id: responseId(turn.messageId),
+    object: "response",
+    created_at: createdAt,
+    status,
+    error: null,
+    incomplete_details,
+    model: turn.model,
+    output: encodeResponsesOutput(turn),
+    usage: encodeResponsesUsage(turn),
+    cursor_session_id: turn.sessionId,
+    ...extra,
+  };
+}
+
+export function encodeInProgressResponse(input: {
+  id: string;
+  createdAt: number;
+  model: string;
+  sessionId: string;
+}): Record<string, unknown> {
+  return {
+    id: input.id,
+    object: "response",
+    created_at: input.createdAt,
+    status: "in_progress",
+    error: null,
+    incomplete_details: null,
+    model: input.model,
+    output: [],
+    usage: null,
+    cursor_session_id: input.sessionId,
+  };
+}
+
+export function textOf(blocks: AnthropicContentBlock[], type: "text" | "thinking"): string {
+  return blocks
+    .filter((block) => block.type === type)
+    .map((block) => (block.type === "text" ? block.text : block.type === "thinking" ? block.thinking : ""))
+    .join("");
+}

--- a/src/protocols/openai-responses/parse.ts
+++ b/src/protocols/openai-responses/parse.ts
@@ -1,0 +1,474 @@
+import { invalidRequest } from "../../errors.js";
+import { collectImages, parseContinuation, parseModelParams } from "../anthropic/parse.js";
+import type {
+  AnthropicContentBlock,
+  AnthropicMessage,
+  AnthropicTool,
+} from "../anthropic/types.js";
+import type { ParsedResponses } from "./types.js";
+
+export function parseResponsesRequest(body: unknown): ParsedResponses {
+  if (!body || typeof body !== "object") {
+    throw invalidRequest("JSON object body is required");
+  }
+  const raw = body as Record<string, unknown>;
+  rejectUnsupported(raw);
+  if (typeof raw.model !== "string" || !raw.model.trim()) {
+    throw invalidRequest("model is required");
+  }
+  if (raw.input === undefined) {
+    if (raw.messages !== undefined) {
+      throw invalidRequest("Responses requires input; use /v1/chat/completions for messages");
+    }
+    throw invalidRequest("input is required");
+  }
+
+  const systemParts: string[] = [];
+  if (raw.instructions !== undefined) {
+    systemParts.push(parseInstructions(raw.instructions));
+  }
+  if (typeof raw.system === "string" && raw.system.trim()) {
+    systemParts.push(raw.system);
+  } else if (raw.system !== undefined && raw.instructions === undefined) {
+    systemParts.push(parseInstructions(raw.system));
+  } else if (raw.system !== undefined && typeof raw.system !== "string") {
+    throw invalidRequest("system must be a string if provided");
+  }
+
+  const parsedInput = parseInput(raw.input);
+  systemParts.push(...parsedInput.systemParts);
+  const messages = parsedInput.messages;
+  const tools = Array.isArray(raw.tools) ? raw.tools.map(parseResponsesTool) : [];
+  const names = new Set<string>();
+  for (const tool of tools) {
+    if (names.has(tool.name)) throw invalidRequest(`duplicate tool name: ${tool.name}`);
+    names.add(tool.name);
+  }
+
+  const lastUser = [...messages].reverse().find((message) => message.role === "user");
+  const continuation = lastUser ? parseContinuation(lastUser) : undefined;
+  const images = collectImages(messages);
+
+  return {
+    parsed: {
+      model: raw.model.trim(),
+      modelParams: parseModelParams(raw),
+      stream: raw.stream === true,
+      systemText: systemParts.filter(Boolean).join("\n"),
+      messages,
+      tools,
+      images,
+      lastUser,
+      continuation,
+    },
+  };
+}
+
+function rejectUnsupported(raw: Record<string, unknown>): void {
+  if (raw.previous_response_id != null && raw.previous_response_id !== "") {
+    throw invalidRequest(
+      "previous_response_id is not supported; use function_call_output.call_id to resume a pending tool turn, or x-cursor-session-id for a completed follow-up",
+    );
+  }
+  if (raw.store === true) {
+    throw invalidRequest("store=true is not supported");
+  }
+  if (raw.background === true) {
+    throw invalidRequest("background mode is not supported");
+  }
+  if (raw.conversation !== undefined && raw.conversation !== null) {
+    throw invalidRequest("conversation is not supported");
+  }
+  if (raw.include !== undefined && raw.include !== null) {
+    throw invalidRequest("include expansions are not supported");
+  }
+  if (raw.parallel_tool_calls === false) {
+    throw invalidRequest("parallel_tool_calls=false is not supported");
+  }
+  if (raw.tool_choice !== undefined && raw.tool_choice !== "auto") {
+    throw invalidRequest("tool_choice must be auto or omitted");
+  }
+  if (raw.text !== undefined) {
+    const text = raw.text;
+    if (!text || typeof text !== "object" || Array.isArray(text)) {
+      throw invalidRequest("text must be an object if provided");
+    }
+    const format = (text as { format?: unknown }).format;
+    if (format !== undefined) {
+      const type = format && typeof format === "object" ? (format as { type?: unknown }).type : undefined;
+      if (type !== "text") {
+        throw invalidRequest('text.format must be omitted or {type:"text"}');
+      }
+    }
+  }
+}
+
+function parseInstructions(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    return value
+      .map((part) => {
+        if (part && typeof part === "object") {
+          const raw = part as Record<string, unknown>;
+          if (raw.type === "input_text" || raw.type === "text" || raw.type === "output_text") {
+            return typeof raw.text === "string" ? raw.text : "";
+          }
+        }
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+  throw invalidRequest("instructions must be a string or text part array");
+}
+
+function parseResponsesTool(value: unknown): AnthropicTool {
+  if (!value || typeof value !== "object") throw invalidRequest("tool must be an object");
+  const raw = value as Record<string, unknown>;
+  if (raw.type !== "function") {
+    throw invalidRequest(
+      `unsupported Responses tool type: ${String(raw.type)}; hosted tools (web_search, file_search, computer, shell, apply_patch) are not implemented`,
+    );
+  }
+  const nested = raw.function && typeof raw.function === "object" ? (raw.function as Record<string, unknown>) : undefined;
+  const name = typeof raw.name === "string" ? raw.name : typeof nested?.name === "string" ? nested.name : undefined;
+  if (!name || !/^[a-zA-Z0-9_-]{1,128}$/.test(name)) {
+    throw invalidRequest("tool name must match [a-zA-Z0-9_-]{1,128}");
+  }
+  const description =
+    typeof raw.description === "string"
+      ? raw.description
+      : typeof nested?.description === "string"
+        ? nested.description
+        : undefined;
+  const parameters = raw.parameters ?? nested?.parameters;
+  return {
+    name,
+    description,
+    input_schema:
+      parameters && typeof parameters === "object"
+        ? (parameters as Record<string, unknown>)
+        : { type: "object", properties: {} },
+  };
+}
+
+function parseInput(input: unknown): { messages: AnthropicMessage[]; systemParts: string[] } {
+  if (typeof input === "string") {
+    if (!input.trim()) throw invalidRequest("input must be a non-empty string or item array");
+    return { messages: [{ role: "user", content: input }], systemParts: [] };
+  }
+  if (!Array.isArray(input) || input.length === 0) {
+    throw invalidRequest("input must be a non-empty string or item array");
+  }
+  assertFunctionOutputsAreSuffix(input);
+
+  const messages: AnthropicMessage[] = [];
+  const systemParts: string[] = [];
+  let pendingResults: Extract<AnthropicContentBlock, { type: "tool_result" }>[] = [];
+  let pendingAssistant: AnthropicContentBlock[] = [];
+
+  const flushResults = () => {
+    if (pendingResults.length === 0) return;
+    messages.push({ role: "user", content: pendingResults });
+    pendingResults = [];
+  };
+  const flushAssistant = () => {
+    if (pendingAssistant.length === 0) return;
+    messages.push(packAssistant(pendingAssistant));
+    pendingAssistant = [];
+  };
+
+  for (const item of input) {
+    if (!item || typeof item !== "object") throw invalidRequest("each input item must be an object");
+    const raw = item as Record<string, unknown>;
+    const type = typeof raw.type === "string" ? raw.type : inferItemType(raw);
+
+    if (type === "function_call_output") {
+      flushAssistant();
+      pendingResults.push(parseFunctionCallOutput(raw));
+      continue;
+    }
+
+    flushResults();
+
+    if (type === "function_call") {
+      pendingAssistant.push(parseFunctionCall(raw));
+      continue;
+    }
+    if (type === "reasoning") {
+      const thinking = parseReasoningText(raw);
+      if (thinking) pendingAssistant.push({ type: "thinking", thinking });
+      continue;
+    }
+    if (type === "input_text") {
+      flushAssistant();
+      if (typeof raw.text !== "string") throw invalidRequest("input_text requires text");
+      messages.push({ role: "user", content: raw.text });
+      continue;
+    }
+    if (type === "message" || type === "easy_input_message") {
+      flushAssistant();
+      pushMessageItem(messages, systemParts, raw);
+      continue;
+    }
+    throw invalidRequest(`unsupported input item type: ${String(type)}`);
+  }
+
+  flushResults();
+  flushAssistant();
+  if (messages.length === 0) {
+    throw invalidRequest("input must include a user message or function_call_output");
+  }
+  return { messages, systemParts };
+}
+
+function pushMessageItem(
+  messages: AnthropicMessage[],
+  systemParts: string[],
+  raw: Record<string, unknown>,
+): void {
+  const role = raw.role;
+  if (role === "system" || role === "developer") {
+    const text = stringifyMessageText(raw.content);
+    if (text) systemParts.push(text);
+    return;
+  }
+  if (role === "user" || role === undefined) {
+    messages.push(parseUserItem(raw));
+    return;
+  }
+  if (role === "assistant") {
+    messages.push(parseAssistantItem(raw));
+    return;
+  }
+  throw invalidRequest(`unsupported input message role: ${String(role)}`);
+}
+
+function inferItemType(raw: Record<string, unknown>): string {
+  if (raw.role !== undefined) return "message";
+  if (raw.call_id !== undefined && raw.output !== undefined) return "function_call_output";
+  if (raw.call_id !== undefined && raw.name !== undefined) return "function_call";
+  throw invalidRequest("input item must include type");
+}
+
+function isFunctionCallOutput(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  const raw = value as Record<string, unknown>;
+  if (raw.type === "function_call_output") return true;
+  return raw.type === undefined && raw.call_id !== undefined && raw.output !== undefined;
+}
+
+function assertFunctionOutputsAreSuffix(items: unknown[]): void {
+  let seenOutput = false;
+  for (const item of items) {
+    if (isFunctionCallOutput(item)) {
+      seenOutput = true;
+      continue;
+    }
+    if (seenOutput) {
+      throw invalidRequest(
+        "mixed new text and function_call_output in the latest input is not allowed; function_call_output must be the trailing items",
+      );
+    }
+  }
+}
+
+function parseFunctionCallOutput(
+  raw: Record<string, unknown>,
+): Extract<AnthropicContentBlock, { type: "tool_result" }> {
+  if (typeof raw.call_id !== "string" || !raw.call_id.trim()) {
+    throw invalidRequest("function_call_output must include call_id");
+  }
+  return {
+    type: "tool_result",
+    tool_use_id: raw.call_id,
+    content: stringifyResponsesToolOutput(raw.output),
+    is_error: raw.is_error === true || raw.status === "incomplete",
+  };
+}
+
+function stringifyResponsesToolOutput(output: unknown): string {
+  if (typeof output === "string") return output;
+  if (!Array.isArray(output)) {
+    throw invalidRequest("function_call_output.output must be a string or text content array");
+  }
+  return output
+    .map((part) => {
+      if (!part || typeof part !== "object" || Array.isArray(part)) {
+        throw invalidRequest("function_call_output.output array items must be text content objects");
+      }
+      const raw = part as Record<string, unknown>;
+      if (raw.type !== "input_text" && raw.type !== "output_text" && raw.type !== "text") {
+        throw invalidRequest(
+          `function_call_output.output must contain only text content; unsupported type: ${String(raw.type)}`,
+        );
+      }
+      if (typeof raw.text !== "string") throw invalidRequest(`${String(raw.type)} tool output requires text`);
+      return raw.text;
+    })
+    .join("\n");
+}
+
+function parseFunctionCall(raw: Record<string, unknown>): Extract<AnthropicContentBlock, { type: "tool_use" }> {
+  if (typeof raw.call_id !== "string" || !raw.call_id.trim()) {
+    throw invalidRequest("function_call must include call_id");
+  }
+  if (typeof raw.name !== "string" || !raw.name) {
+    throw invalidRequest("function_call must include name");
+  }
+  return {
+    type: "tool_use",
+    id: raw.call_id,
+    name: raw.name,
+    input: parseToolArguments(raw.arguments),
+  };
+}
+
+function parseToolArguments(value: unknown): unknown {
+  if (value === undefined || value === null || value === "") return {};
+  if (typeof value !== "string") {
+    throw invalidRequest("function_call.arguments must be a JSON string");
+  }
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    throw invalidRequest("function_call.arguments must be valid JSON");
+  }
+}
+
+function parseReasoningText(raw: Record<string, unknown>): string {
+  if (typeof raw.content === "string") return raw.content;
+  const parts: string[] = [];
+  const summary = raw.summary;
+  if (Array.isArray(summary)) {
+    for (const part of summary) {
+      if (part && typeof part === "object" && typeof (part as { text?: unknown }).text === "string") {
+        parts.push((part as { text: string }).text);
+      }
+    }
+  }
+  if (Array.isArray(raw.content)) {
+    for (const part of raw.content) {
+      if (part && typeof part === "object" && typeof (part as { text?: unknown }).text === "string") {
+        parts.push((part as { text: string }).text);
+      }
+    }
+  }
+  return parts.join("");
+}
+
+function parseUserItem(raw: Record<string, unknown>): AnthropicMessage {
+  const blocks = parseUserContent(raw.content);
+  return { role: "user", content: blocks.length === 1 && blocks[0]?.type === "text" ? blocks[0].text : blocks };
+}
+
+function parseAssistantItem(raw: Record<string, unknown>): AnthropicMessage {
+  const blocks = parseAssistantContent(raw.content);
+  if (blocks.length === 0) return { role: "assistant", content: "" };
+  if (blocks.length === 1 && blocks[0]?.type === "text") {
+    return { role: "assistant", content: blocks[0].text };
+  }
+  return { role: "assistant", content: blocks };
+}
+
+function packAssistant(blocks: AnthropicContentBlock[]): AnthropicMessage {
+  if (blocks.length === 1 && blocks[0]?.type === "text") {
+    return { role: "assistant", content: blocks[0].text };
+  }
+  return { role: "assistant", content: blocks };
+}
+
+function parseUserContent(content: unknown): AnthropicContentBlock[] {
+  if (typeof content === "string") return [{ type: "text", text: content }];
+  if (!Array.isArray(content)) {
+    throw invalidRequest("user content must be a string or content part array");
+  }
+  return content.map((part) => parseUserPart(part));
+}
+
+function parseUserPart(part: unknown): AnthropicContentBlock {
+  if (!part || typeof part !== "object") throw invalidRequest("content part must be an object");
+  const raw = part as Record<string, unknown>;
+  if (raw.type === "input_text" || raw.type === "text" || raw.type === "output_text") {
+    if (typeof raw.text !== "string") throw invalidRequest("text part requires text");
+    return { type: "text", text: raw.text };
+  }
+  if (raw.type === "input_image" || raw.type === "image_url") {
+    return parseInputImage(raw);
+  }
+  throw invalidRequest(`unsupported content part type: ${String(raw.type)}`);
+}
+
+function parseAssistantContent(content: unknown): AnthropicContentBlock[] {
+  if (content == null) return [];
+  if (typeof content === "string") return content ? [{ type: "text", text: content }] : [];
+  if (!Array.isArray(content)) {
+    throw invalidRequest("assistant content must be a string, null, or content part array");
+  }
+  return content.map((part) => {
+    if (!part || typeof part !== "object") throw invalidRequest("content part must be an object");
+    const raw = part as Record<string, unknown>;
+    if (raw.type === "output_text" || raw.type === "text" || raw.type === "input_text") {
+      if (typeof raw.text !== "string") throw invalidRequest("text part requires text");
+      return { type: "text", text: raw.text };
+    }
+    throw invalidRequest(`unsupported assistant content part type: ${String(raw.type)}`);
+  });
+}
+
+function parseInputImage(raw: Record<string, unknown>): AnthropicContentBlock {
+  if (raw.file_id !== undefined && raw.file_id !== null) {
+    throw invalidRequest("input_image.file_id is not supported; use a base64 data URL");
+  }
+  const url = readImageUrl(raw);
+  if (!url) {
+    throw invalidRequest("input_image requires image_url");
+  }
+  if (/^https?:\/\//i.test(url) || url.startsWith("//")) {
+    throw invalidRequest("input_image.image_url must be a base64 data URL; remote URLs are not fetched");
+  }
+  const parsed = parseDataUrl(url);
+  if (!parsed) {
+    throw invalidRequest("input_image.image_url must be a base64 data URL; remote URLs are not fetched");
+  }
+  return { type: "image", source: { type: "base64", media_type: parsed.mediaType, data: parsed.data } };
+}
+
+function readImageUrl(raw: Record<string, unknown>): string | undefined {
+  if (typeof raw.image_url === "string") return raw.image_url;
+  if (raw.image_url && typeof raw.image_url === "object") {
+    const url = (raw.image_url as { url?: unknown }).url;
+    if (typeof url === "string") return url;
+  }
+  if (typeof raw.image === "string") return raw.image;
+  return undefined;
+}
+
+function parseDataUrl(url: string): { mediaType: string; data: string } | undefined {
+  const match = /^data:([^;,]+)?(?:;charset=[^;,]+)?;base64,([A-Za-z0-9+/=\s]+)$/i.exec(url.trim());
+  if (!match) return undefined;
+  return {
+    mediaType: match[1]?.trim() || "image/png",
+    data: (match[2] ?? "").replace(/\s+/g, ""),
+  };
+}
+
+function stringifyMessageText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (content == null) return "";
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (part && typeof part === "object") {
+          const raw = part as { type?: string; text?: unknown };
+          if (raw.type === "input_text" || raw.type === "text" || raw.type === "output_text") {
+            return typeof raw.text === "string" ? raw.text : "";
+          }
+        }
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+  throw invalidRequest("message content must be a string or text part array");
+}

--- a/src/protocols/openai-responses/sse.ts
+++ b/src/protocols/openai-responses/sse.ts
@@ -1,0 +1,44 @@
+import type { ServerResponse } from "node:http";
+import { toOpenAIErrorBody } from "../../errors.js";
+import { writeSse } from "../../server/http-util.js";
+
+const nextSequenceByResponse = new WeakMap<ServerResponse, number>();
+
+export function beginResponsesSse(res: ServerResponse, requestId: string, sessionId: string): void {
+  res.writeHead(200, {
+    "content-type": "text/event-stream; charset=utf-8",
+    "cache-control": "no-cache, no-transform",
+    connection: "keep-alive",
+    "x-request-id": requestId,
+    "x-accel-buffering": "no",
+    "x-cursor-session-id": sessionId,
+  });
+}
+
+export function writeResponsesEvent(
+  res: ServerResponse,
+  event: string,
+  data: Record<string, unknown>,
+  sequence: number,
+): void {
+  writeSse(res, event, { ...data, sequence_number: sequence, type: event });
+  nextSequenceByResponse.set(res, sequence + 1);
+}
+
+export function writeResponsesStreamError(
+  res: ServerResponse,
+  error: unknown,
+  requestId: string,
+  sequence?: number,
+): void {
+  const body = toOpenAIErrorBody(error, requestId);
+  const resolvedSequence = sequence ?? nextSequenceByResponse.get(res) ?? 0;
+  writeSse(res, "error", {
+    type: "error",
+    code: body.error.code,
+    message: body.error.message,
+    param: null,
+    sequence_number: resolvedSequence,
+  });
+  nextSequenceByResponse.set(res, resolvedSequence + 1);
+}

--- a/src/protocols/openai-responses/types.ts
+++ b/src/protocols/openai-responses/types.ts
@@ -1,0 +1,7 @@
+import type { ParsedMessages } from "../anthropic/types.js";
+
+export interface ParsedResponses {
+  parsed: ParsedMessages;
+}
+
+export type ResponsesStatus = "in_progress" | "completed" | "incomplete" | "failed";

--- a/src/protocols/openai-responses/writer.ts
+++ b/src/protocols/openai-responses/writer.ts
@@ -1,0 +1,250 @@
+import { responseId } from "../../ids.js";
+import type { TurnWriter, TurnWriterContext, TurnWriterFactory } from "../../core/turn-writer.js";
+import { sendJson, sendOpenAIError } from "../../server/http-util.js";
+import type { AnthropicContentBlock, AssistantTurn } from "../anthropic/types.js";
+import {
+  encodeFunctionCallItem,
+  encodeMessageItem,
+  encodeReasoningItem,
+  encodeResponse,
+  encodeInProgressResponse,
+  functionCallItemId,
+  reasoningItemId,
+  textOf,
+} from "./encode.js";
+import { beginResponsesSse, writeResponsesEvent, writeResponsesStreamError } from "./sse.js";
+
+export function createResponsesWriterFactory(): TurnWriterFactory {
+  return (ctx) => new ResponsesTurnWriter(ctx);
+}
+
+class ResponsesTurnWriter implements TurnWriter {
+  private started = false;
+  private sequence = 0;
+  private nextOutputIndex = 0;
+  private reasoning?: StreamItem;
+  private message?: StreamItem;
+  private readonly id: string;
+  private readonly createdAt: number;
+
+  constructor(private readonly ctx: TurnWriterContext) {
+    this.id = responseId(ctx.messageId);
+    this.createdAt = Math.floor(ctx.session.createdAt / 1000);
+  }
+
+  onThinking(text: string): void {
+    if (!this.ctx.stream || this.dead() || !text) return;
+    this.ensureStart();
+    const item = this.ensureReasoning();
+    item.text += text;
+    this.emit("response.reasoning_summary_text.delta", {
+      item_id: item.itemId,
+      output_index: item.outputIndex,
+      summary_index: 0,
+      delta: text,
+    });
+  }
+
+  onText(text: string): void {
+    if (!this.ctx.stream || this.dead() || !text) return;
+    this.ensureStart();
+    const item = this.ensureMessage();
+    item.text += text;
+    this.emit("response.output_text.delta", {
+      item_id: item.itemId,
+      output_index: item.outputIndex,
+      content_index: 0,
+      delta: text,
+    });
+  }
+
+  finish(turn: AssistantTurn, extra?: { replayed?: boolean }): void {
+    if (!this.ctx.stream) {
+      if (!this.dead()) {
+        sendJson(
+          this.ctx.res,
+          200,
+          encodeResponse(turn, this.createdAt, extra?.replayed ? { replayed: true } : {}),
+          this.ctx.requestId,
+          { "x-cursor-session-id": turn.sessionId },
+        );
+      }
+      return;
+    }
+    if (this.dead()) return;
+    this.ensureStart();
+    this.emitRemaining(turn);
+    this.emit(
+      "response.completed",
+      {
+        response: encodeResponse(turn, this.createdAt, extra?.replayed ? { replayed: true } : {}),
+      },
+    );
+    this.ctx.res.end();
+  }
+
+  fail(error: unknown): void {
+    if (this.dead()) return;
+    if (this.ctx.stream && this.ctx.res.headersSent) {
+      writeResponsesStreamError(this.ctx.res, error, this.ctx.requestId, this.sequence++);
+      this.ctx.res.end();
+      return;
+    }
+    sendOpenAIError(this.ctx.res, error, this.ctx.requestId);
+  }
+
+  private emitRemaining(turn: AssistantTurn): void {
+    if (!this.reasoning) {
+      const thinking = textOf(turn.blocks, "thinking");
+      if (thinking) this.onThinking(thinking);
+    }
+    if (!this.message) {
+      const text = textOf(turn.blocks, "text");
+      if (text) this.onText(text);
+    }
+    this.finalizeItems();
+    const tools = turn.blocks.filter(
+      (block): block is Extract<AnthropicContentBlock, { type: "tool_use" }> => block.type === "tool_use",
+    );
+    for (const block of tools) this.emitFunctionCall(block);
+  }
+
+  private ensureReasoning(): StreamItem {
+    if (this.reasoning) return this.reasoning;
+    const outputIndex = this.nextOutputIndex++;
+    const itemId = reasoningItemId(this.ctx.messageId);
+    const item = { ...encodeReasoningItem(this.ctx.messageId, ""), summary: [] };
+    this.emit("response.output_item.added", { output_index: outputIndex, item });
+    this.emit("response.reasoning_summary_part.added", {
+      item_id: itemId,
+      output_index: outputIndex,
+      summary_index: 0,
+      part: { type: "summary_text", text: "" },
+    });
+    this.reasoning = { outputIndex, itemId, text: "", done: false };
+    return this.reasoning;
+  }
+
+  private ensureMessage(): StreamItem {
+    if (this.message) return this.message;
+    const outputIndex = this.nextOutputIndex++;
+    const itemId = this.ctx.messageId;
+    this.emit("response.output_item.added", {
+      output_index: outputIndex,
+      item: encodeMessageItem(itemId, "", "in_progress"),
+    });
+    this.emit("response.content_part.added", {
+      item_id: itemId,
+      output_index: outputIndex,
+      content_index: 0,
+      part: { type: "output_text", text: "", annotations: [] },
+    });
+    this.message = { outputIndex, itemId, text: "", done: false };
+    return this.message;
+  }
+
+  private finalizeItems(): void {
+    if (this.reasoning && !this.reasoning.done) this.closeReasoning(this.reasoning);
+    if (this.message && !this.message.done) this.closeMessage(this.message);
+  }
+
+  private closeReasoning(open: StreamItem): void {
+    this.emit("response.reasoning_summary_text.done", {
+      item_id: open.itemId,
+      output_index: open.outputIndex,
+      summary_index: 0,
+      text: open.text,
+    });
+    this.emit("response.reasoning_summary_part.done", {
+      item_id: open.itemId,
+      output_index: open.outputIndex,
+      summary_index: 0,
+      part: { type: "summary_text", text: open.text },
+    });
+    this.emit("response.output_item.done", {
+      output_index: open.outputIndex,
+      item: encodeReasoningItem(this.ctx.messageId, open.text),
+    });
+    open.done = true;
+  }
+
+  private closeMessage(open: StreamItem): void {
+    this.emit("response.output_text.done", {
+      item_id: open.itemId,
+      output_index: open.outputIndex,
+      content_index: 0,
+      text: open.text,
+    });
+    this.emit("response.content_part.done", {
+      item_id: open.itemId,
+      output_index: open.outputIndex,
+      content_index: 0,
+      part: { type: "output_text", text: open.text, annotations: [] },
+    });
+    this.emit("response.output_item.done", {
+      output_index: open.outputIndex,
+      item: encodeMessageItem(open.itemId, open.text),
+    });
+    open.done = true;
+  }
+
+  private emitFunctionCall(block: Extract<AnthropicContentBlock, { type: "tool_use" }>): void {
+    const outputIndex = this.nextOutputIndex++;
+    const itemId = functionCallItemId(block.id);
+    const argumentsJson = JSON.stringify(block.input ?? {});
+    this.emit("response.output_item.added", {
+      output_index: outputIndex,
+      item: {
+        ...encodeFunctionCallItem(block, "in_progress"),
+        arguments: "",
+      },
+    });
+    if (argumentsJson) {
+      this.emit("response.function_call_arguments.delta", {
+        item_id: itemId,
+        output_index: outputIndex,
+        delta: argumentsJson,
+      });
+    }
+    this.emit("response.function_call_arguments.done", {
+      item_id: itemId,
+      output_index: outputIndex,
+      name: block.name,
+      arguments: argumentsJson,
+    });
+    this.emit("response.output_item.done", {
+      output_index: outputIndex,
+      item: encodeFunctionCallItem(block),
+    });
+  }
+
+  private emit(event: string, data: Record<string, unknown>): void {
+    if (this.dead()) return;
+    writeResponsesEvent(this.ctx.res, event, data, this.sequence++);
+  }
+
+  private ensureStart(): void {
+    if (this.started || this.dead()) return;
+    this.started = true;
+    beginResponsesSse(this.ctx.res, this.ctx.requestId, this.ctx.session.sessionId);
+    const response = encodeInProgressResponse({
+      id: this.id,
+      createdAt: this.createdAt,
+      model: this.ctx.session.modelId,
+      sessionId: this.ctx.session.sessionId,
+    });
+    this.emit("response.created", { response });
+    this.emit("response.in_progress", { response });
+  }
+
+  private dead(): boolean {
+    return this.ctx.res.destroyed || this.ctx.res.writableEnded;
+  }
+}
+
+interface StreamItem {
+  outputIndex: number;
+  itemId: string;
+  text: string;
+  done: boolean;
+}

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -15,6 +15,9 @@ import { writeSseError } from "../protocols/anthropic/sse.js";
 import { parseChatCompletionsRequest } from "../protocols/openai-chat/parse.js";
 import { writeChatStreamError } from "../protocols/openai-chat/sse.js";
 import { createChatWriterFactory } from "../protocols/openai-chat/writer.js";
+import { parseResponsesRequest } from "../protocols/openai-responses/parse.js";
+import { writeResponsesStreamError } from "../protocols/openai-responses/sse.js";
+import { createResponsesWriterFactory } from "../protocols/openai-responses/writer.js";
 import type { SdkRuntime } from "../sdk/port.js";
 import { ModelCatalog } from "../sdk/catalog.js";
 import { headerValue, readJsonBody, requestPath, sendError, sendJson, sendOpenAIError } from "./http-util.js";
@@ -114,6 +117,7 @@ export function createApp(input: {
             verification: {
               live_smoke: false,
               chat_completions: "contract_tested_unverified_live",
+              responses: "contract_tested_unverified_live",
               streaming: "sdk_onDelta",
               thinking: "implemented_unverified_live",
               images: "implemented_unverified_live",
@@ -187,6 +191,24 @@ export function createApp(input: {
         return;
       }
 
+      if (method === "POST" && path === "/v1/responses") {
+        const auth = authenticate(req, config);
+        const body = await readJsonBody(req, config.maxBodyBytes);
+        if (body === undefined) throw invalidRequest("JSON body is required");
+        const responses = parseResponsesRequest(body);
+        const sessionHint = headerValue(req, "x-cursor-session-id");
+        await coordinator.handleMessages(
+          req,
+          res,
+          auth,
+          responses.parsed,
+          requestId,
+          sessionHint,
+          createResponsesWriterFactory(),
+        );
+        return;
+      }
+
       throw notFound(`No route for ${method} ${path}`);
     } catch (error) {
       logger.warn(
@@ -202,11 +224,12 @@ export function createApp(input: {
       if (res.writableEnded || res.destroyed) return;
       if (res.headersSent) {
         if (path === "/v1/chat/completions") writeChatStreamError(res, error, requestId);
+        else if (path === "/v1/responses") writeResponsesStreamError(res, error, requestId);
         else writeSseError(res, toPublicErrorBody(error, requestId));
         res.end();
         return;
       }
-      if (path === "/v1/chat/completions") sendOpenAIError(res, error, requestId);
+      if (path === "/v1/chat/completions" || path === "/v1/responses") sendOpenAIError(res, error, requestId);
       else sendError(res, error, requestId);
     }
   };

--- a/tests/contract/health.test.ts
+++ b/tests/contract/health.test.ts
@@ -13,6 +13,7 @@ test("health reports runtime capability truth without account data", async () =>
       capabilities: {
         messages: true,
         chat_completions: true,
+        responses: true,
         streaming: true,
         thinking: true,
         images: true,
@@ -49,6 +50,7 @@ test("health reports runtime capability truth without account data", async () =>
   expect(body.capabilities).toMatchObject({
     messages: true,
     chat_completions: true,
+    responses: true,
     streaming: true,
     thinking: true,
     images: true,
@@ -66,6 +68,7 @@ test("health reports runtime capability truth without account data", async () =>
     images: "implemented_unverified_live",
     parallel_tools: "implemented_unverified_live",
     chat_completions: "contract_tested_unverified_live",
+    responses: "contract_tested_unverified_live",
   });
   expect(body.verification).not.toHaveProperty("contract_tests");
   expect(JSON.stringify(body)).not.toContain("spending");
@@ -78,6 +81,7 @@ test("health capabilities follow runtime config, not marketing constants", async
       capabilities: {
         messages: true,
         chat_completions: false,
+        responses: false,
         streaming: false,
         thinking: false,
         images: false,

--- a/tests/contract/responses.test.ts
+++ b/tests/contract/responses.test.ts
@@ -1,0 +1,820 @@
+import { afterEach, expect, test } from "vitest";
+import {
+  api,
+  closeTestApp,
+  parseSse,
+  responsesWeatherTool,
+  startTestApp,
+  type TestContext,
+} from "../helpers/app.js";
+
+let ctx: TestContext;
+
+afterEach(async () => {
+  if (ctx) await closeTestApp(ctx);
+});
+
+const tools = [
+  responsesWeatherTool(),
+  {
+    type: "function" as const,
+    name: "beta",
+    description: "Second tool",
+    parameters: { type: "object", properties: { n: { type: "number" } } },
+  },
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function openaiError(body: unknown): { message: string; type: string; param: null; code: string } {
+  const error = isRecord(body) ? body.error : undefined;
+  if (!isRecord(error)) throw new Error("expected OpenAI error object");
+  return error as { message: string; type: string; param: null; code: string };
+}
+
+function outputOfType(body: { output?: unknown[] }, type: string): Record<string, unknown>[] {
+  return (body.output ?? []).filter((item): item is Record<string, unknown> => isRecord(item) && item.type === type);
+}
+
+test("non-stream text returns a response object", async () => {
+  ctx = await startTestApp({
+    sdk: { scripts: [[{ type: "text", chunks: ["hello ", "world"] }]] },
+  });
+  const res = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: "hi",
+    }),
+  });
+  const body = (await res.json()) as {
+    object: string;
+    model: string;
+    status: string;
+    output: Array<{ type: string; role?: string; content?: Array<{ type: string; text?: string }> }>;
+    usage: { input_tokens: number; output_tokens: number; total_tokens: number; usage_status?: string };
+    cursor_session_id: string;
+  };
+  expect(res.status).toBe(200);
+  expect(res.headers.get("x-request-id")).toBeTruthy();
+  expect(res.headers.get("x-cursor-session-id")).toMatch(/^ses_/);
+  expect(body.object).toBe("response");
+  expect(body.model).toBe("composer-2.5");
+  expect(body.status).toBe("completed");
+  expect(body.output).toHaveLength(1);
+  expect(body.output[0]).toMatchObject({
+    type: "message",
+    role: "assistant",
+    status: "completed",
+    content: [{ type: "output_text", text: "hello world", annotations: [] }],
+  });
+  expect(body.usage).toEqual({
+    input_tokens: 0,
+    output_tokens: 0,
+    total_tokens: 0,
+    usage_status: "unavailable",
+  });
+  expect(body.cursor_session_id).toMatch(/^ses_/);
+  expect(ctx.sdk.lastAllowlist).toEqual([]);
+});
+
+test("instructions and developer items stay in system context", async () => {
+  ctx = await startTestApp({
+    sdk: { scripts: [[{ type: "text", chunks: ["ok"] }]] },
+  });
+  const res = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      instructions: "top rule",
+      input: [
+        {
+          type: "message",
+          role: "developer",
+          content: [{ type: "input_text", text: "developer rule" }],
+        },
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "hello" }],
+        },
+      ],
+    }),
+  });
+  expect(res.status).toBe(200);
+  expect(ctx.sdk.agents[0]?.lastSend?.text).toContain("System:\ntop rule\ndeveloper rule");
+  expect(ctx.sdk.agents[0]?.lastSend?.text).toContain("user:\nhello");
+  expect(ctx.sdk.agents[0]?.lastSend?.text).not.toContain("user:\ndeveloper rule");
+});
+
+test("stream lifecycle uses Responses event names and ends with response.completed", async () => {
+  ctx = await startTestApp({
+    sdk: { scripts: [[{ type: "thinking", chunks: ["hmm"] }, { type: "text", chunks: ["A", "B"] }]] },
+  });
+  const res = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      stream: true,
+      input: [{ type: "input_text", text: "hi" }],
+    }),
+  });
+  expect(res.headers.get("content-type")).toContain("text/event-stream");
+  expect(res.headers.get("x-cursor-session-id")).toMatch(/^ses_/);
+  const raw = await res.text();
+  expect(raw).not.toContain("data: [DONE]");
+  const events = parseSse(raw);
+  expect(events.every((event) => isRecord(event.data) && Number.isInteger(event.data.sequence_number))).toBe(true);
+  expect(events.map((event) => event.event).slice(0, 2)).toEqual(["response.created", "response.in_progress"]);
+  expect(events.at(-1)?.event).toBe("response.completed");
+  expect(events.some((event) => event.event === "error")).toBe(false);
+
+  const names = events.map((event) => event.event);
+  const createdAt = names.indexOf("response.created");
+  const reasoningAdded = names.indexOf("response.output_item.added");
+  const reasoningDelta = names.indexOf("response.reasoning_summary_text.delta");
+  const textDelta = names.indexOf("response.output_text.delta");
+  const completedAt = names.lastIndexOf("response.completed");
+  expect(createdAt).toBeLessThan(reasoningAdded);
+  expect(reasoningAdded).toBeLessThan(reasoningDelta);
+  expect(reasoningDelta).toBeLessThan(textDelta);
+  expect(textDelta).toBeLessThan(completedAt);
+
+  const reasoning = events
+    .filter((event) => event.event === "response.reasoning_summary_text.delta")
+    .map((event) => (isRecord(event.data) ? event.data.delta : undefined));
+  const texts = events
+    .filter((event) => event.event === "response.output_text.delta")
+    .map((event) => (isRecord(event.data) ? event.data.delta : undefined));
+  expect(reasoning).toEqual(["hmm"]);
+  expect(texts).toEqual(["A", "B"]);
+
+  const completed = events.at(-1)?.data;
+  expect(isRecord(completed) && isRecord(completed.response)).toBe(true);
+  const response = isRecord(completed) ? (completed.response as Record<string, unknown>) : {};
+  expect(response.status).toBe("completed");
+  expect(outputOfType({ output: response.output as unknown[] }, "reasoning")[0]).toMatchObject({
+    type: "reasoning",
+    summary: [{ type: "summary_text", text: "hmm" }],
+  });
+  expect(outputOfType({ output: response.output as unknown[] }, "message")[0]).toMatchObject({
+    content: [{ type: "output_text", text: "AB" }],
+  });
+});
+
+test("single function_call continuation stays on the same SDK run", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      scripts: [
+        [
+          { type: "tools", calls: [{ name: "lookup", input: { q: "weather" } }] },
+          { type: "text", chunks: ["sunny"] },
+        ],
+      ],
+      finalUsage: { inputTokens: 11, outputTokens: 5, cacheReadTokens: 2, cacheWriteTokens: 4 },
+    },
+  });
+  const first = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: "weather?",
+      tools: [responsesWeatherTool()],
+    }),
+  });
+  const toolTurn = (await first.json()) as {
+    status: string;
+    output: Array<{
+      type: string;
+      call_id?: string;
+      name?: string;
+      arguments?: string;
+    }>;
+    cursor_session_id: string;
+    usage: {
+      input_tokens: number;
+      output_tokens: number;
+      total_tokens: number;
+      usage_deferred?: boolean;
+      usage_status?: string;
+    };
+  };
+  expect(first.status).toBe(200);
+  expect(toolTurn.status).toBe("completed");
+  const call = outputOfType(toolTurn, "function_call")[0];
+  expect(call?.name).toBe("lookup");
+  expect(call?.call_id).toBeTruthy();
+  expect(JSON.parse(String(call?.arguments ?? ""))).toEqual({ q: "weather" });
+  expect(toolTurn.usage).toMatchObject({
+    input_tokens: 0,
+    output_tokens: 0,
+    total_tokens: 0,
+    usage_deferred: true,
+    usage_status: "deferred",
+  });
+  expect(ctx.sdk.agents[0]?.runs[0]?.waitCalls ?? 0).toBe(0);
+
+  const second = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: [
+        { type: "message", role: "user", content: "weather?" },
+        {
+          type: "function_call",
+          call_id: call?.call_id,
+          name: call?.name,
+          arguments: call?.arguments,
+        },
+        { type: "function_call_output", call_id: call?.call_id, output: "72F" },
+      ],
+      tools: [responsesWeatherTool()],
+    }),
+  });
+  const final = (await second.json()) as {
+    id: string;
+    status: string;
+    output: Array<{ type: string; content?: Array<{ text?: string }> }>;
+    usage: {
+      input_tokens: number;
+      output_tokens: number;
+      total_tokens: number;
+      cache_creation_input_tokens?: number;
+      cache_read_input_tokens?: number;
+      input_tokens_details?: { cached_tokens: number };
+      usage_status?: string;
+    };
+  };
+  expect(second.status).toBe(200);
+  expect(final.status).toBe("completed");
+  expect(outputOfType(final, "message")[0]?.content).toEqual([
+    { type: "output_text", text: "sunny", annotations: [] },
+  ]);
+  expect(final.usage).toMatchObject({
+    input_tokens: 11,
+    output_tokens: 5,
+    total_tokens: 16,
+    cache_creation_input_tokens: 4,
+    cache_read_input_tokens: 2,
+    input_tokens_details: { cached_tokens: 2 },
+    usage_status: "sdk",
+  });
+  expect(ctx.sdk.agents.length).toBe(1);
+  expect(ctx.sdk.agents[0]?.runs.length).toBe(1);
+  expect(ctx.sdk.agents[0]?.runs[0]?.waitCalls).toBe(1);
+
+  const replayPayload = {
+    model: "composer-2.5",
+    input: [{ type: "function_call_output", call_id: call?.call_id, output: "72F" }],
+    tools: [responsesWeatherTool()],
+  };
+  const replay = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify(replayPayload),
+  });
+  const replayed = (await replay.json()) as {
+    output: Array<{ type: string; content?: Array<{ text?: string }> }>;
+    replayed?: boolean;
+  };
+  expect(replay.status).toBe(200);
+  expect(outputOfType(replayed, "message")[0]?.content).toEqual([
+    { type: "output_text", text: "sunny", annotations: [] },
+  ]);
+  expect(replayed.replayed).toBe(true);
+  expect(ctx.sdk.agents[0]?.runs[0]?.capturedToolResults).toHaveLength(1);
+
+  const streamReplay = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({ ...replayPayload, stream: true }),
+  });
+  const replayEvents = parseSse(await streamReplay.text());
+  const created = replayEvents.find((event) => event.event === "response.created")?.data;
+  const completed = replayEvents.find((event) => event.event === "response.completed")?.data;
+  expect(isRecord(created) && isRecord(created.response) && created.response.id).toBe(final.id);
+  expect(isRecord(completed) && isRecord(completed.response) && completed.response.id).toBe(final.id);
+  expect(isRecord(completed) && isRecord(completed.response) && completed.response.replayed).toBe(true);
+  expect(ctx.sdk.agents[0]?.runs[0]?.capturedToolResults).toHaveLength(1);
+});
+
+test("parallel function calls require the full output batch", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      scripts: [
+        [
+          {
+            type: "tools",
+            calls: [
+              { name: "lookup", input: { q: "a" } },
+              { name: "beta", input: { n: 2 } },
+            ],
+          },
+          { type: "text", chunks: ["both"] },
+        ],
+      ],
+    },
+  });
+  const first = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "do both" }] }],
+      tools,
+    }),
+  });
+  const toolTurn = (await first.json()) as {
+    output: Array<{ call_id?: string; name?: string; arguments?: string; type: string }>;
+  };
+  const calls = outputOfType(toolTurn, "function_call");
+  expect(calls).toHaveLength(2);
+  expect(calls.map((call) => call.name).sort()).toEqual(["beta", "lookup"]);
+  for (const call of calls) {
+    expect(typeof call.arguments).toBe("string");
+    JSON.parse(String(call.arguments));
+  }
+
+  const missing = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: [{ type: "function_call_output", call_id: calls[0]?.call_id, output: "only-one" }],
+      tools,
+    }),
+  });
+  expect(missing.status).toBe(422);
+  expect(openaiError(await missing.json()).code).toBe("invalid_request");
+
+  const second = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: calls.map((call) => ({
+        type: "function_call_output",
+        call_id: call.call_id,
+        output: "ok",
+      })),
+      tools,
+    }),
+  });
+  const final = (await second.json()) as { output: Array<{ type: string; content?: Array<{ text?: string }> }> };
+  expect(second.status).toBe(200);
+  expect(outputOfType(final, "message")[0]?.content).toEqual([
+    { type: "output_text", text: "both", annotations: [] },
+  ]);
+});
+
+test("function_call_output text content arrays are passed as tool text", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      scripts: [
+        [
+          { type: "tools", calls: [{ name: "lookup", input: { q: "weather" } }] },
+          { type: "text", chunks: ["done"] },
+        ],
+      ],
+    },
+  });
+  const first = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({ model: "composer-2.5", input: "weather?", tools: [responsesWeatherTool()] }),
+  });
+  const call = outputOfType((await first.json()) as { output: unknown[] }, "function_call")[0];
+  const second = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: [
+        {
+          type: "function_call_output",
+          call_id: call?.call_id,
+          output: [
+            { type: "input_text", text: "72F" },
+            { type: "input_text", text: "sunny" },
+          ],
+        },
+      ],
+      tools: [responsesWeatherTool()],
+    }),
+  });
+  expect(second.status).toBe(200);
+  expect(ctx.sdk.agents[0]?.runs[0]?.capturedToolResults).toEqual(["72F\nsunny"]);
+});
+
+test("unsupported function_call_output image and file parts fail closed without consuming the tool", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      scripts: [
+        [
+          { type: "tools", calls: [{ name: "lookup", input: { q: "weather" } }] },
+          { type: "text", chunks: ["done"] },
+        ],
+      ],
+    },
+  });
+  const first = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({ model: "composer-2.5", input: "weather?", tools: [responsesWeatherTool()] }),
+  });
+  const call = outputOfType((await first.json()) as { output: unknown[] }, "function_call")[0];
+  const unsupported = [
+    { type: "input_image", image_url: "data:image/png;base64,YQ==" },
+    { type: "input_file", file_id: "file_test" },
+    { type: "unknown", value: "nope" },
+  ];
+  for (const output of unsupported) {
+    const rejected = await api(ctx, "/v1/responses", {
+      method: "POST",
+      body: JSON.stringify({
+        model: "composer-2.5",
+        input: [{ type: "function_call_output", call_id: call?.call_id, output: [output] }],
+        tools: [responsesWeatherTool()],
+      }),
+    });
+    expect(rejected.status).toBe(422);
+    expect(openaiError(await rejected.json()).message).toMatch(/function_call_output/);
+    expect(ctx.sdk.agents[0]?.runs[0]?.capturedToolResults).toHaveLength(0);
+  }
+  const accepted = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: [{ type: "function_call_output", call_id: call?.call_id, output: "72F" }],
+      tools: [responsesWeatherTool()],
+    }),
+  });
+  expect(accepted.status).toBe(200);
+  expect(ctx.sdk.agents[0]?.runs[0]?.capturedToolResults).toEqual(["72F"]);
+});
+
+test("interleaved thinking and text keep one stable item per output kind", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      scripts: [
+        [
+          { type: "thinking", chunks: ["a"] },
+          { type: "text", chunks: ["answer"] },
+          { type: "thinking", chunks: ["b"] },
+        ],
+      ],
+    },
+  });
+  const res = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({ model: "composer-2.5", stream: true, input: "hi" }),
+  });
+  const events = parseSse(await res.text());
+  const added = events.filter((event) => event.event === "response.output_item.added");
+  const done = events.filter((event) => event.event === "response.output_item.done");
+  expect(added).toHaveLength(2);
+  expect(done).toHaveLength(2);
+  const addedIds = added.map((event) => (isRecord(event.data) && isRecord(event.data.item) ? event.data.item.id : undefined));
+  expect(new Set(addedIds).size).toBe(2);
+  const completed = events.find((event) => event.event === "response.completed")?.data;
+  const output = isRecord(completed) && isRecord(completed.response) ? (completed.response.output as unknown[]) : [];
+  expect(outputOfType({ output }, "reasoning")[0]).toMatchObject({
+    summary: [{ type: "summary_text", text: "ab" }],
+  });
+  expect(outputOfType({ output }, "message")[0]).toMatchObject({
+    content: [{ type: "output_text", text: "answer" }],
+  });
+});
+
+test("stream function_call arguments are JSON on the done event", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      scripts: [[{ type: "tools", calls: [{ name: "lookup", input: { q: "weather" } }] }, { type: "text", chunks: ["later"] }]],
+    },
+  });
+  const res = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      stream: true,
+      input: "weather?",
+      tools: [responsesWeatherTool()],
+    }),
+  });
+  const events = parseSse(await res.text());
+  const sequences = events.map((event) => (isRecord(event.data) ? event.data.sequence_number : undefined));
+  expect(sequences).toEqual(sequences.map((_, index) => index));
+  expect(events.at(-1)?.event).toBe("response.completed");
+  const done = events.find((event) => event.event === "response.function_call_arguments.done");
+  expect(isRecord(done?.data)).toBe(true);
+  expect(isRecord(done?.data) && done.data.name).toBe("lookup");
+  expect(JSON.parse(String(isRecord(done?.data) ? done?.data.arguments : ""))).toEqual({ q: "weather" });
+  const completed = events.at(-1)?.data;
+  const output = isRecord(completed) && isRecord(completed.response) ? (completed.response.output as unknown[]) : [];
+  expect(outputOfType({ output }, "function_call")[0]).toMatchObject({
+    type: "function_call",
+    name: "lookup",
+  });
+});
+
+test("reasoning_effort reuses existing model parameter rules", async () => {
+  ctx = await startTestApp({
+    sdk: { scripts: [[{ type: "text", chunks: ["ok"] }]] },
+  });
+  const res = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "grok-4.6",
+      reasoning: { effort: "xhigh" },
+      cursor_model_params: [{ id: "fast", value: "false" }],
+      input: "hi",
+    }),
+  });
+  expect(res.status).toBe(200);
+  expect(ctx.sdk.lastCreate?.modelId).toBe("grok-4.6");
+  expect(ctx.sdk.lastCreate?.modelParams).toEqual([
+    { id: "effort", value: "xhigh" },
+    { id: "fast", value: "false" },
+  ]);
+});
+
+test("base64 input_image is forwarded to the SDK", async () => {
+  ctx = await startTestApp({
+    sdk: { scripts: [[{ type: "text", chunks: ["seen"] }]] },
+  });
+  const data = "aGVsbG8=";
+  const res = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [
+            { type: "input_text", text: "what is this" },
+            { type: "input_image", image_url: `data:image/png;base64,${data}` },
+          ],
+        },
+      ],
+    }),
+  });
+  expect(res.status).toBe(200);
+  expect(ctx.sdk.agents[0]?.lastSend?.images).toEqual([{ data, mimeType: "image/png" }]);
+});
+
+test("remote input_image fails closed instead of dropping the image", async () => {
+  ctx = await startTestApp();
+  const res = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_image", image_url: "https://example.com/cat.png" }],
+        },
+      ],
+    }),
+  });
+  const error = openaiError(await res.json());
+  expect(res.status).toBe(422);
+  expect(error.type).toBe("invalid_request_error");
+  expect(error.code).toBe("invalid_request");
+  expect(error.param).toBeNull();
+  expect(ctx.sdk.lastCreate).toBeUndefined();
+});
+
+test("previous_response_id and hosted tools fail closed", async () => {
+  ctx = await startTestApp();
+  const previous = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      previous_response_id: "resp_pretend",
+      input: "hi",
+    }),
+  });
+  const previousError = openaiError(await previous.json());
+  expect([400, 422]).toContain(previous.status);
+  expect(previousError.code).toBe("invalid_request");
+  expect(previousError.message).toMatch(/previous_response_id/);
+
+  const hosted = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: "search",
+      tools: [{ type: "web_search" }],
+    }),
+  });
+  const hostedError = openaiError(await hosted.json());
+  expect([400, 422]).toContain(hosted.status);
+  expect(hostedError.code).toBe("invalid_request");
+  expect(hostedError.message).toMatch(/web_search/);
+  expect(ctx.sdk.lastCreate).toBeUndefined();
+});
+
+test("Responses tool_choice other than auto fails closed", async () => {
+  ctx = await startTestApp();
+  const res = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: "hi",
+      tool_choice: "required",
+    }),
+  });
+  expect(res.status).toBe(422);
+  expect(openaiError(await res.json()).message).toMatch(/tool_choice/);
+  expect(ctx.sdk.lastCreate).toBeUndefined();
+});
+
+test("store=true and mixed function_call_output fail closed", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      scripts: [[{ type: "tools", calls: [{ name: "lookup", input: { q: "1" } }] }, { type: "text", chunks: ["final"] }]],
+    },
+  });
+  const stored = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      store: true,
+      input: "hi",
+    }),
+  });
+  expect(openaiError(await stored.json()).message).toMatch(/store=true/);
+
+  const first = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: "go",
+      tools: [responsesWeatherTool()],
+    }),
+  });
+  const call = outputOfType((await first.json()) as { output: unknown[] }, "function_call")[0];
+  const mixed = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: [
+        { type: "function_call_output", call_id: call?.call_id, output: "x" },
+        { type: "message", role: "user", content: "also this" },
+      ],
+    }),
+  });
+  expect(mixed.status).toBe(422);
+  expect(openaiError(await mixed.json()).message).toMatch(/mixed/i);
+});
+
+test("unknown and missing function_call_output ids fail closed", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      scripts: [[{ type: "tools", calls: [{ name: "lookup", input: { q: "1" } }] }, { type: "text", chunks: ["final"] }]],
+    },
+  });
+  const first = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: "go",
+      tools: [responsesWeatherTool()],
+    }),
+  });
+  const unknown = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: [{ type: "function_call_output", call_id: "call_missing", output: "x" }],
+    }),
+  });
+  const error = openaiError(await unknown.json());
+  expect([400, 409, 422]).toContain(unknown.status);
+  expect(["invalid_request", "cursor_session_lost"]).toContain(error.code);
+  expect(error.param).toBeNull();
+  expect(error.message).toBeTruthy();
+
+  const missingId = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: [{ type: "function_call_output", output: "x" }],
+    }),
+  });
+  expect([400, 422]).toContain(missingId.status);
+  expect(openaiError(await missingId.json()).message).toMatch(/call_id/);
+  expect(first.status).toBe(200);
+});
+
+test("function_call_output ids from different sessions fail closed", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      agentScripts: [
+        [[{ type: "tools", calls: [{ name: "lookup", input: { q: "a" } }] }, { type: "text", chunks: ["a"] }]],
+        [[{ type: "tools", calls: [{ name: "lookup", input: { q: "b" } }] }, { type: "text", chunks: ["b"] }]],
+      ],
+    },
+  });
+  const first = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({ model: "composer-2.5", input: "a", tools: [responsesWeatherTool()] }),
+  });
+  const second = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({ model: "composer-2.5", input: "b", tools: [responsesWeatherTool()] }),
+  });
+  const firstCall = outputOfType((await first.json()) as { output: unknown[] }, "function_call")[0];
+  const secondCall = outputOfType((await second.json()) as { output: unknown[] }, "function_call")[0];
+  const mixed = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: [
+        { type: "function_call_output", call_id: firstCall?.call_id, output: "a" },
+        { type: "function_call_output", call_id: secondCall?.call_id, output: "b" },
+      ],
+    }),
+  });
+  expect(mixed.status).toBe(409);
+  expect(openaiError(await mixed.json()).code).toBe("cursor_session_conflict");
+  expect(ctx.sdk.agents[0]?.runs[0]?.capturedToolResults).toHaveLength(0);
+  expect(ctx.sdk.agents[1]?.runs[0]?.capturedToolResults).toHaveLength(0);
+});
+
+test("in-stream SDK errors use a Responses error event and no completed", async () => {
+  ctx = await startTestApp({
+    sdk: { scripts: [[{ type: "text", chunks: ["partial"] }, { type: "error", message: "upstream failed" }]] },
+  });
+  const res = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      stream: true,
+      input: "hi",
+    }),
+  });
+  const events = parseSse(await res.text());
+  const sequences = events.map((event) => (isRecord(event.data) ? event.data.sequence_number : undefined));
+  expect(sequences).toEqual(sequences.map((_, index) => index));
+  expect(events.some((event) => event.event === "response.completed")).toBe(false);
+  expect(
+    events.some(
+      (event) =>
+        event.event === "response.output_text.delta" &&
+        isRecord(event.data) &&
+        event.data.delta === "partial",
+    ),
+  ).toBe(true);
+  const failure = events.find((event) => event.event === "error");
+  expect(failure?.event).toBe("error");
+  expect(failure?.data).toMatchObject({
+    type: "error",
+    code: "cursor_upstream_error",
+    sequence_number: expect.any(Number),
+  });
+});
+
+test("OpenAI error shape is used before the stream starts", async () => {
+  ctx = await startTestApp();
+  const res = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({ model: "composer-2.5", input: [] }),
+  });
+  const body = (await res.json()) as { error: { message: string; type: string; param: null; code: string }; type?: string };
+  expect([400, 422]).toContain(res.status);
+  expect(body.type).toBeUndefined();
+  expect(body.error.message).toBeTruthy();
+  expect(body.error.type).toBe("invalid_request_error");
+  expect(body.error.param).toBeNull();
+  expect(body.error.code).toBe("invalid_request");
+  expect(res.headers.get("x-request-id")).toBeTruthy();
+});
+
+test("completed follow-up with x-cursor-session-id reuses the Agent", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      scripts: [[{ type: "text", chunks: ["first"] }], [{ type: "text", chunks: ["second"] }]],
+    },
+  });
+  const first = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: "first",
+    }),
+  });
+  const sessionId = ((await first.json()) as { cursor_session_id: string }).cursor_session_id;
+  const follow = await api(ctx, "/v1/responses", {
+    method: "POST",
+    headers: { "x-cursor-session-id": sessionId },
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: "second",
+    }),
+  });
+  const body = (await follow.json()) as { output: Array<{ type: string; content?: Array<{ text?: string }> }> };
+  expect(follow.status).toBe(200);
+  expect(follow.headers.get("x-cursor-session-id")).toBe(sessionId);
+  expect(outputOfType(body, "message")[0]?.content).toEqual([
+    { type: "output_text", text: "second", annotations: [] },
+  ]);
+  expect(ctx.sdk.agents.length).toBe(1);
+  expect(ctx.sdk.agents[0]?.runs.length).toBe(2);
+});

--- a/tests/helpers/app.ts
+++ b/tests/helpers/app.ts
@@ -126,6 +126,19 @@ export function openaiWeatherTool() {
   };
 }
 
+export function responsesWeatherTool() {
+  return {
+    type: "function" as const,
+    name: "lookup",
+    description: "Look something up",
+    parameters: {
+      type: "object",
+      properties: { q: { type: "string" } },
+      required: ["q"],
+    },
+  };
+}
+
 export function parseChatSse(text: string): Array<Record<string, unknown> | "[DONE]"> {
   const frames: Array<Record<string, unknown> | "[DONE]"> = [];
   for (const chunk of text.split("\n\n")) {


### PR DESCRIPTION
## What changed

- add `POST /v1/responses` on the existing Messages run/session engine
- translate Responses input items, reasoning, base64 images, function tools, parallel tool batches, continuation, replay, usage, and SSE events
- preserve fail-closed boundaries for unsupported OpenAI store/background/conversation/hosted-tool semantics
- expose honest Responses capability and verification state in `/health`
- document the endpoint in English and Chinese

## Why

Cursor SDK clients should be able to use the same native Harness through Anthropic Messages, OpenAI Chat Completions, or OpenAI Responses without duplicating run ownership or weakening tenant/session isolation.

## Review findings closed

Grok's read-only review found three protocol issues. This branch now:

- rejects image/file/unknown `function_call_output` parts with `422` instead of silently JSON-stringifying them
- keeps streaming `sequence_number` strictly monotonic through the real outer error path
- keeps stable reasoning/message item identities for interleaved thinking and text

The follow-up Grok review returned `approve` with no remaining high/medium findings.

## Validation

- `npm run typecheck`
- `npm test` — 18 files, 126 tests passed
- `npm run build`
- `git diff --check`
- `npm pack --dry-run` — no tarball left behind
- Docker build/run smoke: `/health`, `/console/`, and unauthenticated `/v1/responses` error shape
- local image manifest list: `sha256:6b811caf1588653ffe024f92405774961d71443686c3e071c44238e765bd4a54`

## Boundaries

- no real Cursor credential or live Codex/OpenCode model matrix was used for this PR
- `/health` reports Responses as `contract_tested_unverified_live`
- no npm package, GHCR image, or production deployment is published by this PR
- runtime `npm audit` still reports the known official `@cursor/sdk` transitive dependency findings
