### PR TITLE
Rewrite launch documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,46 +2,110 @@
 
 [简体中文](README.zh-CN.md)
 
-Independent MIT gateway that exposes the official Cursor TypeScript SDK (`@cursor/sdk`) as Anthropic- and OpenAI-compatible HTTP APIs.
+Independent MIT gateway that turns the official published Cursor TypeScript SDK (`@cursor/sdk`) into three HTTP dialects: Anthropic Messages, OpenAI Chat Completions, and OpenAI Responses.
 
-This is **not** an official Cursor or Anysphere product. Model execution does not reverse private Cursor transports, cookies, Desktop/CLI stores, or IDE sessions; the only execution engine is the published `@cursor/sdk` package. Account usage optionally calls the Cursor Dashboard control plane with the same User API Key, as documented below. Users must supply a legally obtained Cursor API key and comply with Cursor Terms of Service.
+**Claude Code-first. Grok Build-ready. Codex/Responses-compatible.** The tested Claude path covers streaming, multi-round and same-turn parallel client tools, cache-aware usage, completed-session resume, and Claude Code context sizing. When Cursor's live catalog exposes `context=1m`, the gateway forwards that official model parameter unchanged to `@cursor/sdk`.
 
-**v0.1 is Anthropic Messages-first.** `/v1/chat/completions` and `/v1/responses` are protocol adapters over that same run engine (contract-tested, not live-model certified).
+This is **not** a Cursor or Anysphere product. It does not reverse private Cursor transports, cookies, Desktop/CLI stores, or browser sessions. The only model execution engine is the published `@cursor/sdk` package. You supply a legally obtained Cursor User API Key (or Service Account key) and stay inside Cursor's Terms of Service.
 
-## What v0.1 includes
+[![CI](https://github.com/Sunnyender-org/cursor-sdk2api/actions/workflows/ci.yml/badge.svg)](https://github.com/Sunnyender-org/cursor-sdk2api/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Node](https://img.shields.io/badge/node-%3E%3D22.19-339933)](package.json)
+[![@cursor/sdk](https://img.shields.io/badge/%40cursor%2Fsdk-1.0.28-111111)](https://www.npmjs.com/package/@cursor/sdk)
 
-| Method | Path | Auth | Notes |
-|---|---|---|---|
-| `GET` | `/console/` | none | Optional BF Labs Operator Console with CPA-style persistent account files under `STATE_DIR/auths`. |
-| `GET` | `/health` | none | Build, SDK version, readiness, **implemented** capability bits, network transport modes, and a separate `verification` object. Capability `true` means the gateway implements the path; it is not a live-model acceptance claim. `/health` never includes account data, keys, or proxy URLs. |
-| `GET` | `/v1/models` | required | Live `Cursor.models.list()` catalog with exact public IDs. Empty list plus an explicit reason when unavailable. |
-| `GET` | `/v1/account` | required | Identity from `Cursor.me()` plus current billing-cycle usage from Cursor Dashboard using the same User API Key. No Cookie, Team Admin key, or OAuth token is required. |
-| `POST` | `/v1/messages/count_tokens` | required | Local conservative estimate for Claude Code context sizing. Marked by `x-cursor-sdk2api-token-count: estimated`; never used for billing. |
-| `POST` | `/v1/messages` | required | Anthropic Messages text, SSE, client tools, same-turn parallel tools, multi-round continuation, and in-process replay. |
-| `POST` | `/v1/chat/completions` | required | OpenAI Chat Completions adapter: text, `data:` SSE + `[DONE]`, function tools, continuation, `reasoning_content`, base64 `image_url`. Same session/run engine as Messages. |
-| `POST` | `/v1/responses` | required | OpenAI Responses adapter: `input` string or items, Responses SSE + `response.completed`, reasoning, base64 `input_image`, `type=function` tools, `function_call_output` continuation by `call_id`. Same session/run engine as Messages. `previous_response_id` / hosted tools / `store=true` fail closed. The Console playground supports Responses directly. |
+**v0.1 is a single-process trusted sidecar.** `/v0/management/accounts` has no access key and returns raw Cursor keys to the same-origin Operator Console. Keep it on a trusted local network, or put TLS and your own auth proxy in front.
 
-Default **API Compatibility Profile**:
+## Why this exists
 
-- Request `tools[]` map to SDK `local.customTools`.
-- Built-in allowlist is `["mcp"]` when client tools exist, otherwise `[]`.
-- Ambient Cursor capabilities (`shell`, `read`, `edit`, `task`, `webSearch`, `webFetch`) are denied.
-- `settingSources: []` and an empty workspace. The caller's repo is never implied.
+Most "CLI to API" gateways wrap Claude Code, Codex, or Grok login state. This one does the opposite.
+
+You already have a Cursor API key. Cursor already publishes `@cursor/sdk`. Coding agents already speak Messages or Responses. `cursor-sdk2api` is the missing HTTP edge: one process, one run coordinator, three protocol adapters, no second Cursor runtime hidden in cookies.
+
+What works today:
+
+- Claude Code over **Messages**, including SSE, client tool loops, same-turn parallel tools, cache usage, completed-session resume, and `count_tokens` as a marked local estimate
+- Grok Build over **Responses**, including Grok's named-function tool choice and the optional `reasoning.encrypted_content` include (accepted, then omitted)
+- OpenAI SDK / generic Chat clients over **Chat Completions**
+- Codex and other Responses clients over **Responses**, where they do not require `previous_response_id`, `store=true`, or hosted tools
+- Caller-owned tools (Claude Code / Grok / Codex local tools, including that client's own web or network search if it exposes one)
+- Same-turn parallel tool callbacks, multi-round continuation, streaming, base64 images, and thinking/reasoning blocks (implemented and contract-tested; live thinking granularity is still unverified)
+- Live `GET /v1/models` catalog with exact public IDs
+- `GET /v1/account` identity plus Cursor Dashboard quota from the same User API Key
+- Optional Operator Console at `/console/`
+- Outbound HTTP(S) proxy for both SDK data planes
+
+What this is not:
+
+- Not a drop-in Anthropic, OpenAI, or xAI replacement
+- Not a reverse-engineered Cursor IDE proxy
+- Not an xAI-native Grok endpoint (`x_search` is not here)
+- Not a multi-instance high-availability cluster
+
+## Client compatibility
+
+Point each client at the protocol it already speaks. Mixing them on one channel is the usual way to get a 422.
+
+| Client | Use | Do not |
+|---|---|---|
+| **Claude Code** | `ANTHROPIC_BASE_URL` = gateway origin → `POST /v1/messages` | Chat Completions. Claude Code needs Messages, including `max_tokens` and `count_tokens`. |
+| **Grok Build** | custom model `api_backend = "responses"` → `POST /v1/responses` | Messages. If the client later sends `previous_response_id`, this gateway returns 422; switch that model to `chat_completions`. |
+| **Codex / OpenAI Responses** | `base_url` `…/v1`, `wire_api = "responses"` → `POST /v1/responses` | Assume OpenAI store semantics. `previous_response_id`, `store=true`, conversation objects, and hosted tools fail closed. |
+| **OpenAI SDK / generic Chat** | `base_url` `…/v1` → `POST /v1/chat/completions` | Messages unless the client is Anthropic-shaped. |
+| **new-api / one-api** | Anthropic upstream = origin (Messages); OpenAI upstream = `origin/v1` (Chat) | Mix both on one channel. There is no official new-api channel PR yet; configure a generic sidecar. |
+
+Claude Code, Grok Build, and Codex edit **your local project** with **their** tools. The gateway only runs the model. Cursor SDK `cwd` is an empty per-credential directory, so the model may emit that absolute path. Prefer relative paths, or your real project path.
+
+**Claude 1M context.** Cursor's live catalog currently exposes `context=1m` for models including Claude Sonnet 4.6 and Fable 5. This gateway preserves the exact public model ID and forwards the official SDK `{id,value}` parameter unchanged. It does not invent a context window or emulate Anthropic long-context billing. The 1M catalog path is verified; a synthetic one-million-token payload benchmark is not part of the published receipt.
+
+**Web / network search.** Client-owned search tools stay on the client. If Claude Code, Grok Build, or Codex expose a local web or network search tool, the gateway maps it like any other caller tool and returns the client's result. Cursor ambient `webSearch` / `webFetch` are denied. Hosted OpenAI `web_search` is rejected. **Cursor-routed Grok does not expose xAI-native `x_search`.** That tool exists on xAI's own API, not on this Cursor SDK path.
+
+Compatibility evidence:
+
+- Claude Code: the full host Sonnet 4.6 and Fable 5 Messages matrix passed, including text, SSE, single/parallel/multi-round tools, replay, cache reads/writes, and completed resume. A Claude Code-shaped Fable 5 request passed the published matrix; a later real Claude Code operator probe completed against Sonnet 4.6 and used local workspace tools.
+- Grok Build: Responses adapter is contract-tested for Grok's named tool choice, usage detail objects, and the known encrypted-reasoning include. A local operator probe completed a real Grok Build Responses session and wrote a workspace marker. Same limit: connect + local-tool evidence.
+- Codex: Responses contract suite exists. No Codex live-client receipt is in this repository.
+
+## Capability matrix
+
+`GET /health` capabilities mean the gateway implements the path. They are not a live-model acceptance stamp. `verification.live_smoke` stays `false` in the binary.
+
+| Capability | Status | Boundary |
+|---|---|---|
+| Anthropic Messages text + SSE | Implemented; live-sampled on Sonnet 4.6, Fable 5, Composer 2.5, Grok 4.6 xhigh | Dated host receipt: [docs/evidence/2026-08-15-live-smoke.md](docs/evidence/2026-08-15-live-smoke.md) |
+| OpenAI Chat Completions | Protocol adapter; contract-tested | Health marks `contract_tested_unverified_live`. No live Chat matrix. |
+| OpenAI Responses | Protocol adapter; contract-tested | Same health mark. Grok Build connect is locally probed. Codex is not live-certified. |
+| Claude `count_tokens` | Local conservative estimate | Header `x-cursor-sdk2api-token-count: estimated`. Never starts an SDK run. Never used for billing. |
+| Claude 1M context | Catalog / param passthrough | Exact Cursor IDs and official SDK params only. No 1M-token acceptance in this repo. |
+| Thinking / reasoning | Implemented; contract-tested | Live thinking granularity is still a separate model gate. Grok encrypted reasoning include is accepted and omitted. |
+| Images | Implemented; contract-tested | Base64 only. Remote `image_url` is `422`. |
+| Caller tools via custom MCP | Implemented | Request `tools[]` → SDK `local.customTools`. Allowlist is `["mcp"]` when caller tools exist, else `[]`. |
+| Same-turn parallel tools | Implemented; live-sampled on Claude / Composer | Grok same-turn two-tool selection was **not repeatable** in the published receipt. Do not treat it as guaranteed. |
+| Multi-round tool continuation | Implemented; live-sampled | Latest user turn must be only `tool_result` / `function_call_output`. Mixed text + results is `422`. |
+| Client web / network search | Only if the **client** owns the tool | Mapped as a normal caller tool. Not granted by the gateway. |
+| Cursor ambient `shell` / `read` / `edit` / `task` / `webSearch` / `webFetch` | Denied | Empty workspace. `settingSources: []`. |
+| xAI `x_search` | **Not available** | Cursor-routed Grok is still Cursor. Use an xAI-native API if you need `x_search`. |
+| Hosted OpenAI tools (`web_search`, `file_search`, `computer`, `shell`, `apply_patch`) | Fail closed | `422` |
+| Responses `previous_response_id` / `store=true` / conversation | Fail closed | Continuation is `function_call_output.call_id` or `x-cursor-session-id`. |
+| In-process live tool continuation | Process-local Promises | One owner process. Pending callbacks cannot be serialized as-is. |
+| Pending-tool restart recovery | Implemented; fake-SDK integration-tested | Exact credential / model / params / tool-id batch / catalog, then `Agent.resume` + `local.force=true`. The published 2026-08-15 live smoke still recorded `409 cursor_session_lost` (that runner expected the old fail-closed path). |
+| Completed follow-up resume | Implemented; live-sampled | `x-cursor-session-id` within `SESSION_TTL_MS`. |
+| Cursor Dashboard quota | Implemented | Same User API Key. No Cookie, Team Admin key, or OAuth import. Missing usage is `partial`, never a fake zero. |
+| Outbound HTTP(S) proxy | Implemented; container-probed | Both SDK data planes. SOCKS / PAC fail closed. |
 
 ## Quick start
 
 Requires Node.js 22.19 or newer.
 
 ```bash
+git clone https://github.com/Sunnyender-org/cursor-sdk2api.git
+cd cursor-sdk2api
 npm ci
 npm run build
 export AUTH_MODE=byok
 node dist/index.js
 ```
 
-Open `http://localhost:8080/console/` for the optional Operator Console. Cursor
-account files are stored server-side under `STATE_DIR/auths` with `0700` directory
-and `0600` file permissions, so accounts survive page and gateway restarts.
+Open [http://localhost:8080/console/](http://localhost:8080/console/). Add a Cursor API key there, or send it on every request.
 
 ```bash
 curl -s localhost:8080/health
@@ -53,7 +117,7 @@ curl -s localhost:8080/v1/messages \
   -d '{"model":"composer-2.5","max_tokens":64,"messages":[{"role":"user","content":"hello"}]}'
 ```
 
-Docker:
+### Docker
 
 ```bash
 docker build -t cursor-sdk2api:local .
@@ -64,14 +128,14 @@ docker run --rm -p 8080:8080 -e AUTH_MODE=byok cursor-sdk2api:local
 
 Copy [`.env.example`](.env.example) for the full configuration surface. Never commit real keys.
 
-## Outbound proxy
+### Outbound proxy
 
-The official SDK does not automatically inherit the host proxy. When a supported proxy variable is set, the gateway routes **both** SDK data planes:
+The official SDK does not inherit the host proxy by itself. When a supported proxy variable is set, the gateway routes **both** SDK data planes:
 
 - local Agent runs switch to HTTP/1.1 through `proxy-agent`
-- catalog, account, and Cursor Dashboard usage fetches use Undici's environment proxy dispatcher
+- catalog, account, and Cursor Dashboard fetches use Undici's environment proxy dispatcher
 
-`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY` are accepted in uppercase or lowercase. Proxy URLs must use `http://` or `https://`. SOCKS and PAC fail closed, because the two SDK data planes cannot support them consistently. Direct (unproxied) Agent runs keep the official HTTP/2 transport.
+`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY` are accepted in uppercase or lowercase. Proxy URLs must be `http://` or `https://`. SOCKS and PAC fail closed. Direct Agent runs keep the official HTTP/2 transport.
 
 `/health` reports only `network.proxy_configured`, `network.agent_transport`, and `network.fetch_transport`. Proxy URLs and credentials are never returned.
 
@@ -82,7 +146,7 @@ export NO_PROXY=127.0.0.1,localhost
 node dist/index.js
 ```
 
-Inside Docker Desktop, a proxy running on the host is `host.docker.internal`, not `127.0.0.1` inside the container:
+Inside Docker Desktop, a proxy on the host is `host.docker.internal`, not `127.0.0.1` inside the container:
 
 ```bash
 docker run --rm -p 8080:8080 \
@@ -93,68 +157,172 @@ docker run --rm -p 8080:8080 \
   cursor-sdk2api:local
 ```
 
-Do not put proxy userinfo in compose files or docs. Prefer a credential-free loopback URL, or keep credentials in a separately protected environment.
+Do not put proxy userinfo in compose files or docs.
+
+## Client configuration
+
+Replace the origin if the gateway is not on loopback. In BYOK mode the key is the Cursor API key. In managed mode it is `GATEWAY_ACCESS_KEY`.
+
+### Claude Code → Messages
+
+```bash
+export ANTHROPIC_BASE_URL=http://127.0.0.1:8080
+export ANTHROPIC_AUTH_TOKEN="$CURSOR_API_KEY"
+export ANTHROPIC_MODEL=claude-sonnet-4-6
+claude
+```
+
+Claude Code sends `x-api-key`. The gateway accepts that or `Authorization: Bearer`. Keep `ANTHROPIC_BASE_URL` at the origin (no `/v1`); Claude Code appends `/v1/messages`.
+
+Fable 5 may be missing from Privacy Mode or Team catalogs until you approve Fable 5 data retention in the [Cursor Dashboard](https://cursor.com/dashboard/restricted_models/claude-fable-5).
+
+### Grok Build → Responses
+
+```toml
+[models]
+default = "cursor-gw"
+
+[model.cursor-gw]
+name = "cursor-sdk2api"
+base_url = "http://127.0.0.1:8080/v1"
+api_key = "<cursor-api-key>"
+model = "grok-4.6"
+api_backend = "responses"
+```
+
+Grok's local `web_search` / `web_fetch` (if you leave them enabled) run **in Grok**, then come back as ordinary function results. They are not Cursor ambient tools and they are not xAI `x_search`.
+
+### Codex / OpenAI Responses
+
+```toml
+model = "composer-2.5"
+model_provider = "cursor-sdk2api"
+
+[model_providers.cursor-sdk2api]
+name = "cursor-sdk2api"
+base_url = "http://127.0.0.1:8080/v1"
+wire_api = "responses"
+env_key = "CURSOR_API_KEY"
+```
+
+Or with the OpenAI SDK:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:8080/v1", api_key=CURSOR_API_KEY)
+client.responses.create(model="composer-2.5", input="hello")
+```
+
+Do not send `previous_response_id`. Pending tools resume with trailing `function_call_output` items whose `call_id` matches the live tool id. Completed follow-up uses `x-cursor-session-id`. If your Codex build insists on stored-response IDs, this gateway will 422; use Chat Completions instead.
+
+### OpenAI Chat Completions
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:8080/v1", api_key=CURSOR_API_KEY)
+client.chat.completions.create(
+    model="composer-2.5",
+    messages=[{"role": "user", "content": "hello"}],
+)
+```
+
+### new-api / generic SDK sidecar
+
+```text
+Base URL (Anthropic upstream):  http://<gateway-host>:8080
+Base URL (OpenAI upstream):     http://<gateway-host>:8080/v1
+API key:                        Cursor key (BYOK) or GATEWAY_ACCESS_KEY (managed)
+Model discovery:                GET /v1/models
+```
+
+Do not embed `@cursor/sdk` inside another gateway process. This process stays a sidecar.
+
+## Endpoints
+
+| Method | Path | Auth | Notes |
+|---|---|---|---|
+| `GET` | `/console/` | none to load the page | Optional BF Labs Operator Console. |
+| `GET` / `POST` / `DELETE` | `/v0/management/accounts` | **none in v0.1** | Lists, adds, and deletes persisted Cursor keys. Returns the raw key. Trusted network or auth proxy only. |
+| `GET` | `/health` | none | Build, SDK version, readiness, capability bits, transport modes, `verification`. Never includes account data, keys, or proxy URLs. |
+| `GET` | `/v1/models` | required | Live `Cursor.models.list()` with exact public IDs. Empty list plus a reason when unavailable. |
+| `GET` | `/v1/account` | required | `Cursor.me()` identity plus current-period Dashboard usage from the same User API Key. |
+| `POST` | `/v1/messages/count_tokens` | required | Local estimate for Claude Code context sizing. |
+| `POST` | `/v1/messages` | required | Anthropic Messages text, SSE, caller tools, parallel tools, multi-round continuation, in-process replay. |
+| `POST` | `/v1/chat/completions` | required | OpenAI Chat adapter on the same run engine. |
+| `POST` | `/v1/responses` | required | OpenAI Responses adapter on the same run engine. |
+
+Default **API Compatibility Profile** (all three inference endpoints):
+
+- Request `tools[]` map to SDK `local.customTools`
+- Built-in allowlist is `["mcp"]` when caller tools exist, otherwise `[]`
+- Ambient Cursor capabilities (`shell`, `read`, `edit`, `task`, `webSearch`, `webFetch`) are denied
+- `settingSources: []` and an empty workspace. The caller's repo is never implied
 
 ## Authentication
 
-**BYOK (default).** Each request sends a Cursor API key as `Authorization: Bearer` or `x-api-key`. The process keeps the key in memory only and isolates sessions by an irreversible fingerprint.
+**BYOK (default).** Each request sends a Cursor API key as `Authorization: Bearer` or `x-api-key`. The process keeps the key in memory and isolates sessions by an irreversible fingerprint.
 
 **Managed (optional).** The process holds `CURSOR_API_KEY`. Clients send a different `GATEWAY_ACCESS_KEY`. Health does not expose the managed Cursor identity.
 
-**Console accounts.** The local console adds, lists, and removes Cursor account files in `STATE_DIR/auths`. These files contain the raw Cursor API key and must be treated as secrets. The v0.1 console management endpoint has no separate access key, so keep the console on a trusted local network or behind your own authentication proxy.
+**Console accounts.** The console writes Cursor account files under `STATE_DIR/auths` (`0700` directory, `0600` files, plaintext secrets). Reloading the page reloads those keys from `/v0/management/accounts`. That management route has no separate access key.
 
 Forbidden: browser cookies, Desktop/CLI private stores, email/password login, refresh-token import, and putting keys in URLs, model names, or tool IDs.
 
-## API examples
+## Operator Console and quota
 
-Non-stream Messages returns an assistant message plus `cursor_session_id` (`ses_...`). Use that value as `x-cursor-session-id` for a completed follow-up:
+`/console/` is static Vite assets served by the same Node process. No second production service.
 
-```bash
-curl -s localhost:8080/v1/messages \
-  -H "Authorization: Bearer $CURSOR_API_KEY" \
-  -H "content-type: application/json" \
-  -H "x-cursor-session-id: ses_replace_me" \
-  -d '{"model":"composer-2.5","max_tokens":64,"messages":[{"role":"user","content":"continue"}]}'
+- Overview: health, SDK version, transport mode
+- Accounts: add / list / remove persisted Cursor keys
+- Quota: current-period spend, remaining included usage, plan metadata, model-family percentages when Dashboard returns them
+- Playground: Messages, Chat Completions, and Responses
+- Connect: the same client recipes as this README
+- English / Chinese, light / dark
+
+`/v1/account` uses the User API Key twice: official `Cursor.me()` for identity, then a short-lived Dashboard access token for `GetCurrentPeriodUsage` and `GetPlanInfo`. No Cookie, Team Admin key, or OAuth token. If Dashboard is down, identity can still return and the body is `status: partial` with an explicit reason. Missing usage is omitted, never invented as zero.
+
+## Architecture and tool ownership
+
+```
+Claude Code | Grok Build | Codex | OpenAI SDK | new-api | curl
+        |
+        v
+HTTP /v1/messages | /v1/chat/completions | /v1/responses
+        |
+        v
+protocol parse (Chat / Responses -> canonical ParsedMessages)
+        |
+        v
+RunCoordinator
+  SessionRegistry   (fingerprint, model, tool_use_id, TTL)
+  ToolBridge        (caller tools -> local.customTools)
+  EventPump         (one run.stream() consumer)
+  protocol writer   (Anthropic SSE | Chat data: | Responses events)
+        |
+        v
+official @cursor/sdk  (Agent / Run / Jsonl store / models.list / me)
 ```
 
-Chat Completions uses the same session header. Non-stream returns `cursor_session_id` and `x-cursor-session-id`. Trailing `role:tool` messages continue the pending SDK run:
+Chat Completions and Responses do not own a second session engine. Only the parser and HTTP writer differ.
 
-```bash
-curl -s localhost:8080/v1/chat/completions \
-  -H "Authorization: Bearer $CURSOR_API_KEY" \
-  -H "content-type: application/json" \
-  -d '{"model":"composer-2.5","messages":[{"role":"user","content":"hello"}]}'
-```
+Two different "tools" exist. Mixing them up is how people invent `x_search` and silent shell access.
 
-`n` must be `1` or omitted. Remote `image_url` URLs are rejected (`422`); send a base64 data URL. Stream frames are OpenAI `data:` chunks with a blank line after each frame (no Anthropic event names) and end with `data: [DONE]`. `stream_options.include_usage=true` adds a `choices=[]` usage chunk before `[DONE]`.
+| Owner | What runs | Where it runs |
+|---|---|---|
+| Claude Code / Grok / Codex | Their local tools: read, edit, shell, and that client's web/network search if enabled | Your project directory, in the client process |
+| This gateway | Model inference + tool *selection* | `@cursor/sdk` Agent with an empty cwd |
+| Cursor ambient tools | `shell`, `read`, `edit`, `task`, `webSearch`, `webFetch` | **Denied** |
+| xAI | `x_search` and other xAI-native hosted tools | **Not on this path** |
 
-`/v1/responses` uses the same run engine. Completed follow-up still takes `x-cursor-session-id`. Pending tools resume only when the latest `input` items are `function_call_output` and `call_id` matches the live tool id. `previous_response_id` is rejected; this is not a stateless OpenAI store.
+When caller tools are present, the prompt tells the model that custom MCP tools execute in the API caller's environment and that the SDK cwd is not authoritative.
 
-```bash
-curl -s localhost:8080/v1/responses \
-  -H "Authorization: Bearer $CURSOR_API_KEY" \
-  -H "content-type: application/json" \
-  -d '{"model":"composer-2.5","input":"hello"}'
-```
+## Protocol notes
 
-Stream events use Responses names (`response.created` … `response.completed`). On error the stream emits a Responses `error` event and does not emit `response.completed`. Hosted tools, `store=true`, background, conversation, and unknown include expansions fail closed. Grok's optional `reasoning.encrypted_content` include is accepted but omitted.
+Non-stream Messages returns an assistant message plus `cursor_session_id` (`ses_...`). Send that value as `x-cursor-session-id` for a completed follow-up.
 
-`function_call_output.output` accepts a string or an array of text content parts. Image/file tool-output parts fail closed with `422` until they can be mapped to the SDK without semantic loss.
-
-Keep the public catalog model ID unchanged. For Grok 4.6 xhigh:
-
-```json
-{
-  "model": "grok-4.6",
-  "reasoning_effort": "xhigh",
-  "max_tokens": 64,
-  "messages": [{ "role": "user", "content": "hello" }]
-}
-```
-
-Advanced callers may pass validated official SDK pairs in `cursor_model_params`. An explicit parameter change on the same session is `409 cursor_session_conflict`.
-
-Tool continuation uses the same process-local Agent/Run. The latest user turn must contain only `tool_result` blocks:
+Tool continuation uses the same process-local Agent/Run. The latest user turn must contain only `tool_result` blocks, matched by `tool_use_id` (order is not authoritative).
 
 ```json
 {
@@ -175,94 +343,59 @@ Tool continuation uses the same process-local Agent/Run. The latest user turn mu
 }
 ```
 
-For `/v1/messages`, `max_tokens` is accepted so Claude Code-shaped requests parse. The SDK harness has no precise max-token enforcement, and the gateway does not emulate one. Tool choice is mapped into Harness directives: Messages supports `auto` / `any` / named `tool`; Chat and Responses support `auto` / `required` / named `function`. Serial-tool flags are honored; `tool_choice=none` remains fail closed.
+Chat Completions uses the same session header. Trailing `role:tool` messages continue the pending run. `n` must be `1` or omitted. Stream frames are OpenAI `data:` chunks ending with `data: [DONE]`.
 
-Errors:
+Responses pending tools resume only when the latest `input` items are `function_call_output` and each `call_id` matches a live tool id. `function_call_output.output` accepts a string or text parts. Image or file tool-output parts are `422` until they can be mapped to the SDK without loss. Stream events use Responses names (`response.created` … `response.completed`). On error the stream emits a Responses `error` event and does not emit `response.completed`.
+
+Keep the public catalog model ID unchanged. For Grok 4.6 xhigh:
 
 ```json
 {
-  "type": "error",
-  "error": { "type": "invalid_request", "message": "..." },
-  "request_id": "req_..."
+  "model": "grok-4.6",
+  "reasoning_effort": "xhigh",
+  "max_tokens": 64,
+  "messages": [{ "role": "user", "content": "hello" }]
 }
 ```
 
+Advanced callers may pass validated official SDK pairs in `cursor_model_params`. Changing explicit parameters on the same session is `409 cursor_session_conflict`.
+
+`max_tokens` is accepted so Claude Code-shaped requests parse. The SDK harness has no precise max-token enforcement, and the gateway does not emulate one. Tool choice maps into Harness directives: Messages supports `auto` / `any` / named `tool`; Chat and Responses support `auto` / `required` / named `function`. Serial-tool flags are honored. `tool_choice=none` fails closed.
+
+`temperature`, `top_p`, and `stop_sequences` are accepted and **not mapped** to `@cursor/sdk`.
+
+Default tool-batch debounce is 1500ms from the latest callback (`TOOL_BATCH_SETTLE_MS`). Live SDK probes saw Claude callbacks more than one second apart in one assistant turn.
+
+Usage: intermediate tool turns return zero usage with `usage_deferred: true`. Cumulative SDK usage is confirmed once on the final turn via `run.wait()`. Cache and reasoning fields appear only when the SDK reports them.
+
 Public error types: `invalid_request`, `authentication_error`, `forbidden`, `cursor_session_conflict`, `cursor_session_lost`, `rate_limited`, `cursor_empty_turn`, `cursor_upstream_error`, `cursor_timeout`.
 
-## Native tool loop
+## Security and limitations
 
-The broker holds one SDK Agent/Run in process.
+Treat v0.1 as a trusted local sidecar.
 
-1. The first request may return N `tool_use` blocks from the same assistant turn.
-2. The next request must send only `tool_result` blocks in the latest user turn.
-3. Results are matched by `tool_use_id`. Order is not authoritative.
-4. Wrong, missing, mixed-session, or duplicate-different IDs fail closed.
-5. Duplicate-same results replay the stored turn and do not resolve again.
-6. The HTTP sink is attached before deferred tool promises resolve.
-7. `run.stream()` has a single consumer.
-
-The default tool-batch debounce is 1500ms from the latest callback (`TOOL_BATCH_SETTLE_MS`). Live SDK probes observed Claude callbacks more than one second apart in one assistant turn; publishing on the first callback would hide later pending calls.
-
-Pending callbacks are ordinary in-memory Promises. They cannot be serialized across processes.
-
-## Usage and cache
-
-- Intermediate tool turns return zero usage with `usage_deferred: true`.
-- Cumulative SDK usage is confirmed once on the final turn via `run.wait()`.
-- Cache fields appear only when the SDK reports them. Missing fields are omitted, never invented.
-
-## State, resume, and multi-instance
-
-MVP owns live runs in the process that created them.
-
-- Blue/green and multi-instance deploys need connection draining and sticky ownership of a session.
-- After a process restart, an unfinished tool continuation can resume when credential, model, model params, complete tool-id batch, and tool catalog match the owner-only lineage record.
-- The gateway will not create a new Agent to pretend the original pending Run was recovered.
-
-Completed follow-up with `x-cursor-session-id` can `Agent.resume` within `SESSION_TTL_MS` when credential, model, and explicit model parameters match. Pending tool recovery uses the same SDK store plus `local.force=true`; health reports `pending_tool_restart_resume=true` after a real kill/restart acceptance.
-
-`STATE_DIR` holds:
-
-- optional Operator Console account files at `$STATE_DIR/auths` (`0700` / `0600`; plaintext secrets)
-- official JSONL SDK store at `$STATE_DIR/sdk-store/<credential-fingerprint>`
-- owner-only lineage metadata at `$STATE_DIR/lineage` (`0700` / `0600`)
-
-Host/dev default is `$TMPDIR/cursor-sdk2api/state`. The image and compose default is `/data`. Lineage stores resume metadata only (session id, SDK agent id, fingerprint, model, explicit params, state, pending tool ids/names, optional result digest, timestamps). It does not store API keys, prompts, tool inputs, or tool results. Assistant replay bodies are not persisted.
-
-BYOK credentials share process capacity limits, but official SDK stores and empty workspaces are partitioned by credential fingerprint. That is process-local tenant isolation, not a claim of hardened hostile multi-tenant hosting.
-
-Development defaults: 4 global active runs, 2 per credential, 30 minute session TTL, 10 minute replay TTL, 60 minute run deadline. Active-run limits apply to create, completed follow-up, and persisted resume. Drain still accepts awaiting `tool_result`.
-
-## Status and evidence
-
-v0.1 implements Messages text/SSE, client customTools/MCP, same-turn parallel tools, multi-round continuation, in-process replay, tenant/model isolation, completed Agent resume, and exact pending-tool restart recovery. Chat Completions and Responses are protocol adapters on the same coordinator. The Operator Console playground can exercise all three protocols.
-
-A sanitized, non-secret acceptance summary is in [`docs/evidence/2026-08-15-live-smoke.md`](docs/evidence/2026-08-15-live-smoke.md). That receipt is a dated local sample, not a guarantee for every credential, region, or image:
-
-- Host Claude Sonnet 4.6 and Fable 5 passed the required proxied matrix, including parallel tools and a Claude Code-shaped Fable request.
-- Composer 2.5 passed the required host matrix, including same-turn parallel selection.
-- Grok 4.6 xhigh Responses passed named-tool continuation, full-history continuation, same-turn two-tool parallel selection, cache-aware usage, local client-workspace file edits, and forced kill/restart pending-tool recovery.
-- A Node 22 container proved both SDK data planes honor a configured HTTP(S) proxy, and fail when that proxy is unreachable. Fable container parallel/upstream success was **not** perfectly repeatable and is **not** marketed as a fully green container matrix.
-- Runtime `/health.verification.live_smoke` stays `false`. A binary cannot infer that a different deployment inherited this receipt.
-
-Thinking and image blocks are implemented and contract-tested. Live thinking/image granularity remains a separate model gate.
-
-## Known limitations
-
-- Official `@cursor/sdk` is required at runtime. Its own license and Cursor Terms apply. See [NOTICE.md](NOTICE.md).
-- Production `npm audit --omit=dev` (2026-08-15) reports 3 transitive findings in the SDK tree: `undici` (high) and `@connectrpc/connect-node` / `@cursor/sdk` (moderate). `fixAvailable` is false. Do not run a destructive `npm audit fix`.
-- Cursor Dashboard usage is queried by exchanging the supplied User API Key for a short-lived dashboard access token, then calling `GetCurrentPeriodUsage` and `GetPlanInfo`. If that control plane is unavailable, identity still returns and `/v1/account` degrades to `partial` with an explicit reason.
-- `count_tokens` is an estimate because `@cursor/sdk` has no tokenizer preflight API. Final SDK usage remains authoritative for accounting.
-- Cross-machine recovery still requires the same persisted SDK/lineage state; a stateless replica without that state fails closed.
-- Credentialed live-model tests are opt-in and are not part of default CI.
+- `/v0/management/accounts` has no access key and returns raw Cursor keys.
+- Account JSON under `STATE_DIR/auths` is plaintext. Prefer an encrypted volume.
+- `STATE_DIR/sdk-store` is the official SDK conversation/checkpoint store. This gateway does not audit those files.
+- Lineage under `STATE_DIR/lineage` stores resume metadata only (session id, agent id, fingerprint, model, params, pending tool ids/names, optional result digest). No API keys, prompts, or tool payloads.
+- Live tool callbacks are in-memory Promises. Multi-instance and blue/green deploys need drain plus sticky ownership.
+- After a crash, pending recovery requires the same `STATE_DIR` and an exact identity/catalog/result-batch match. A mismatch is `409`, not a silent new Agent. Duplicate-same after restart has no persisted assistant body.
+- Do not enable payload logging, `DEBUG=*`, or `DEBUG=proxy-agent` on a shared host.
+- Public Internet still needs TLS, an auth proxy, encrypted state, monitoring, and an explicit threat model. Process-local fingerprint isolation is not hostile multi-tenant hosting.
+- Official `@cursor/sdk` license and Cursor Terms still apply. See [NOTICE.md](NOTICE.md).
+- Production `npm audit --omit=dev` (2026-08-15) reports 3 transitive findings in the SDK tree (`undici` high; `@connectrpc/connect-node` / `@cursor/sdk` moderate). `fixAvailable` is false. Do not run a destructive `npm audit fix`.
 
 Not implemented:
 
-- Responses `previous_response_id` reconstruction, `store=true`, background mode, conversation objects, `include` expansions, or hosted built-in tools (`web_search`, `file_search`, `computer`, `shell`, `apply_patch`)
+- Responses `previous_response_id` reconstruction, `store=true`, background mode, conversation objects, unknown `include` expansions, hosted built-in tools
+- xAI-native `x_search`
 - Cursor Agent Profile (`/v1/agents`, native shell/edit, plan mode)
-- distributed session ownership / Redis / Postgres
+- Distributed session ownership / Redis / Postgres
+- An official new-api channel type
 
-## Development
+Development defaults: 4 global active runs, 2 per credential, 30 minute session TTL, 10 minute replay TTL, 60 minute run deadline. Drain still accepts awaiting `tool_result`. Host default `STATE_DIR` is `$TMPDIR/cursor-sdk2api/state`. Image and compose default is `/data`.
+
+## Testing, evidence, status
 
 ```bash
 npm ci
@@ -271,20 +404,28 @@ npm test
 npm run build
 ```
 
-`npm run dev` builds the console once and starts the gateway. For isolated UI
-iteration, run `npm run dev:web`; Vite serves the frontend while API requests can
-be proxied only when explicitly configured by the developer.
+`npm run dev` builds the console once and starts the gateway. `npm run dev:web` is UI-only.
 
-Tests inject a deterministic fake SDK. They never read real Cursor credentials. GitHub Actions CI in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs typecheck, tests, build, and `docker build`.
+Tests inject a deterministic fake SDK. They never read real Cursor credentials. CI in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs typecheck, tests, build, and `docker build`.
 
-Opt-in live matrix (not default CI, not run by `npm test`):
+Opt-in live matrix (not default CI, not `npm test`):
 
 ```bash
 npm run build
 CURSOR_LIVE_SMOKE=1 CURSOR_API_KEY=... npm run live:smoke
 ```
 
-The runner binds loopback only, writes a redacted receipt under temp, and never logs keys, prompts, or tool payloads. See [`scripts/live-smoke/README.md`](scripts/live-smoke/README.md).
+The runner binds loopback only and writes a redacted receipt. See [`scripts/live-smoke/README.md`](scripts/live-smoke/README.md).
+
+Published sample: [`docs/evidence/2026-08-15-live-smoke.md`](docs/evidence/2026-08-15-live-smoke.md). Dated, credential-specific, not inherited by a different binary.
+
+- Host Claude Sonnet 4.6 and Fable 5 passed the required proxied Messages matrix, including parallel tools and a Claude Code-shaped Fable request.
+- Composer 2.5 passed that host matrix, including same-turn parallel selection.
+- Grok 4.6 xhigh passed text, SSE, single tool, multi-round, replay, pending-restart fail-closed (then `409`), and completed resume. Same-turn parallel was observed once and missed later; do not market it as guaranteed.
+- A Node 22 container proved both SDK data planes honor a configured HTTP(S) proxy and fail when that proxy is unreachable. Fable container parallel/upstream success was not fully repeatable.
+- Later local operator probes (not published receipts) connected real Claude Code (Sonnet 4.6) and Grok Build (Responses, Grok 4.6) and confirmed those clients executed their own workspace file tools.
+
+v0.1. Chat Completions and Responses are adapters on the Messages run engine. npm publish, GHCR digest, and a new-api upstream PR are separate later decisions.
 
 ## Docs
 
@@ -294,30 +435,9 @@ The runner binds loopback only, writes a redacted receipt under temp, and never 
 | [docs/PROTOCOL_COMPATIBILITY.md](docs/PROTOCOL_COMPATIBILITY.md) | Endpoint and block support matrix |
 | [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) | Local, Docker, drain, and upgrade |
 | [docs/SECURITY.md](docs/SECURITY.md) | Credentials, logging, and threat notes |
-| [docs/NEW_API_INTEGRATION.md](docs/NEW_API_INTEGRATION.md) | Using the gateway as a generic Anthropic upstream |
-| [docs/DELIVERY_PLAN.md](docs/DELIVERY_PLAN.md) | Public roadmap and later phases |
+| [docs/NEW_API_INTEGRATION.md](docs/NEW_API_INTEGRATION.md) | Generic Anthropic / OpenAI sidecar |
+| [docs/DELIVERY_PLAN.md](docs/DELIVERY_PLAN.md) | Public roadmap |
 | [CHANGELOG.md](CHANGELOG.md) | v0.1 notes |
-
-Until a published image digest exists, point Claude Code, OpenCode, or a generic Anthropic client at `http://<gateway-host>:8080` with the Cursor key (BYOK) or gateway access key (managed). Do not embed `@cursor/sdk` inside another gateway process.
-
-### Client to endpoint
-
-| Client | Use | Do not |
-|---|---|---|
-| Claude Code | `ANTHROPIC_BASE_URL` → `POST /v1/messages` | Chat Completions |
-| Grok Build | custom model `api_backend = "responses"` → `POST /v1/responses` | Messages. If the client sends `previous_response_id`, this gateway returns 422; fall back to `chat_completions`. |
-| OpenAI SDK / generic Chat | `base_url` `…/v1` → `POST /v1/chat/completions` | Messages unless the client is Anthropic-shaped |
-| new-api | Anthropic upstream = Messages; OpenAI upstream = Chat | Mixing the two on one channel |
-
-Grok Build and Claude Code edit **your local project** with their own tools. The gateway only runs the model. Cursor SDK `cwd` is an empty per-credential directory, so the model may emit that absolute path. Relative paths or your project paths write local files. A BeefAPI Cursor channel is the same split.
-
-## Security
-
-- Do not enable payload logging on a shared host.
-- Do not set `DEBUG=*` or `DEBUG=proxy-agent` on a shared host; third-party transport logs can print proxy configuration.
-- Treat `STATE_DIR` as owner-only sensitive state. The official SDK store may contain conversation and checkpoint data; this gateway does not audit those files.
-- Public Internet deployment still requires TLS, access controls, encrypted state, monitoring, and an explicit operator threat model.
-- Default logs may include request id, model id, stream flag, status, pending count, and final numeric usage. They must not include keys, cookies, prompts, thinking, tool schemas, tool arguments, or tool results.
 
 ## License and contributing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,45 +2,110 @@
 
 [English](README.md)
 
-独立 MIT 网关：把官方 Cursor TypeScript SDK（`@cursor/sdk`）暴露成 Anthropic 与 OpenAI 兼容 HTTP API。
+独立 MIT 网关：把官方公开发布的 Cursor TypeScript SDK（`@cursor/sdk`）转成三条 HTTP 协议：Anthropic Messages、OpenAI Chat Completions、OpenAI Responses。
 
-这不是 Cursor / Anysphere 官方产品。模型执行不逆向私有 Cursor 传输、Cookie、Desktop/CLI 凭据库或 IDE 会话；唯一执行引擎仍是公开发布的 `@cursor/sdk`。账号用量会按下文说明，用同一把 User API Key 查询 Cursor Dashboard 控制面。使用者必须提供合法获得的 Cursor API Key，并遵守 Cursor 服务条款。
+**Claude Code 优先，Grok Build 可用，兼容 Codex / Responses。** 已验收的 Claude 路径覆盖流式输出、多轮与同轮并行客户端工具、cache usage、已完成会话续聊，以及 Claude Code 上下文估算。Cursor 实时目录暴露 `context=1m` 时，网关会把这个官方模型参数原样交给 `@cursor/sdk`。
 
-**v0.1 以 Anthropic Messages 为先。** `/v1/chat/completions` 和 `/v1/responses` 都是同一套 Run 引擎上的协议适配层（已有 contract 测试，不是真实模型验收声明）。
+这不是 Cursor / Anysphere 官方产品。它不逆向私有 Cursor 传输、Cookie、Desktop/CLI 凭据库或浏览器会话。唯一的模型执行引擎是公开发布的 `@cursor/sdk`。你需要提供合法获得的 Cursor User API Key（或 Service Account Key），并遵守 Cursor 服务条款。
 
-## v0.1 包含什么
+[![CI](https://github.com/Sunnyender-org/cursor-sdk2api/actions/workflows/ci.yml/badge.svg)](https://github.com/Sunnyender-org/cursor-sdk2api/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Node](https://img.shields.io/badge/node-%3E%3D22.19-339933)](package.json)
+[![@cursor/sdk](https://img.shields.io/badge/%40cursor%2Fsdk-1.0.28-111111)](https://www.npmjs.com/package/@cursor/sdk)
 
-| 方法 | 路径 | 认证 | 说明 |
-|---|---|---|---|
-| `GET` | `/console/` | 无 | 可选 BF Labs 运维控制台，账号按 CPA 风格持久化到 `STATE_DIR/auths`。 |
-| `GET` | `/health` | 无 | 构建版本、SDK 版本、就绪状态、**已实现**能力位、网络传输模式，以及独立的 `verification` 对象。能力位为 `true` 只表示网关实现了该路径，不是真实模型验收声明。`/health` 不含账号数据、密钥或代理 URL。 |
-| `GET` | `/v1/models` | 需要 | 实时 `Cursor.models.list()` 目录，保留精确公开模型 ID。不可用时返回空列表并给出明确 reason。 |
-| `GET` | `/v1/account` | 需要 | 身份来自 `Cursor.me()`；同一把 User API Key 直接查询 Cursor Dashboard 当前计费周期用量。无需 Cookie、Team Admin Key 或 OAuth Token。 |
-| `POST` | `/v1/messages/count_tokens` | 需要 | 为 Claude Code 上下文管理提供保守的本地估算，并返回 `x-cursor-sdk2api-token-count: estimated`；不用于计费。 |
-| `POST` | `/v1/messages` | 需要 | Anthropic Messages 文本、SSE、客户端工具、同轮并行工具、多轮 continuation，以及进程内 replay。 |
-| `POST` | `/v1/chat/completions` | 需要 | OpenAI Chat Completions 适配：文本、`data:` SSE + `[DONE]`、function tools、continuation、`reasoning_content`、base64 `image_url`。与 Messages 共用同一套 session/run 引擎。 |
-| `POST` | `/v1/responses` | 需要 | OpenAI Responses 适配：`input` 字符串或 item、Responses SSE + `response.completed`、reasoning、base64 `input_image`、`type=function` 工具、按 `call_id` 续轮 `function_call_output`。与 Messages 共用同一套 session/run 引擎。`previous_response_id` / 托管工具 / `store=true` 会 fail closed。控制台 playground 可直接使用 Responses。 |
+**v0.1 是单进程、可信网络侧车。** `/v0/management/accounts` 没有单独 Access Key，会把原始 Cursor Key 返回给同源运维控制台。请只放在可信本地网络，或在外层加 TLS 和你自己的认证代理。
 
-默认 **API Compatibility Profile**：
+## 为什么做这个
 
-- 请求里的 `tools[]` 映射为 SDK `local.customTools`。
-- 存在客户端工具时内置 allowlist 为 `["mcp"]`，否则为 `[]`。
-- 拒绝 Cursor ambient 能力（`shell`、`read`、`edit`、`task`、`webSearch`、`webFetch`）。
-- `settingSources: []`，并使用空 workspace。不会隐式带上调用方仓库。
+多数「CLI 转 API」网关包的是 Claude Code、Codex 或 Grok 的登录态。这个项目反过来。
+
+你已经有一把合法 Cursor API Key。Cursor 已经发布 `@cursor/sdk`。编码客户端已经会说 Messages 或 Responses。`cursor-sdk2api` 补的是这一层 HTTP 边缘：一个进程、一套 Run 协调器、三个协议适配，不靠 Cookie 里藏第二套 Cursor 运行时。
+
+现在能用的：
+
+- Claude Code 走 **Messages**，覆盖 SSE、客户端工具闭环、同轮并行工具、cache usage、已完成会话续聊，并提供带标记的本地 `count_tokens` 估算
+- Grok Build 走 **Responses**，包含 Grok 的具名 function 工具选择，以及可选的 `reasoning.encrypted_content` include（接受后省略）
+- OpenAI SDK / 通用 Chat 客户端走 **Chat Completions**
+- Codex 和其他 Responses 客户端走 **Responses**，前提是它们不依赖 `previous_response_id`、`store=true` 或托管工具
+- 调用方自己的工具（Claude Code / Grok / Codex 本机工具，包括该客户端自己暴露的网页 / 网络搜索）
+- 同轮并行工具回调、多轮续轮、流式、base64 图片，以及 thinking / reasoning 块（已实现并有 contract 测试；真实模型上的 thinking 粒度仍未验收）
+- 实时 `GET /v1/models`，保留精确公开模型 ID
+- `GET /v1/account`：身份 + 同一把 User API Key 查 Cursor Dashboard 额度
+- 可选运维控制台 `/console/`
+- 两条 SDK 数据通路的出站 HTTP(S) 代理
+
+它不是：
+
+- 不是 Anthropic、OpenAI 或 xAI 的无损替代
+- 不是逆向出来的 Cursor IDE 反代
+- 不是 xAI 原生 Grok 端点（这里没有 `x_search`）
+- 不是多实例高可用集群
+
+## 客户端兼容
+
+让每个客户端打它本来就会的协议。混在同一通道上，最常见的结果是 422。
+
+| 客户端 | 用这个 | 不要用 |
+|---|---|---|
+| **Claude Code** | `ANTHROPIC_BASE_URL` = 网关 origin → `POST /v1/messages` | Chat Completions。Claude Code 需要 Messages，包括 `max_tokens` 和 `count_tokens`。 |
+| **Grok Build** | 自定义模型 `api_backend = "responses"` → `POST /v1/responses` | Messages。若客户端后来带上 `previous_response_id`，本网关会 422；把该模型改成 `chat_completions`。 |
+| **Codex / OpenAI Responses** | `base_url` 指到 `…/v1`，`wire_api = "responses"` → `POST /v1/responses` | 不要假定 OpenAI store 语义。`previous_response_id`、`store=true`、conversation 和托管工具会 fail closed。 |
+| **OpenAI SDK / 通用 Chat** | `base_url` 指到 `…/v1` → `POST /v1/chat/completions` | 除非客户端是 Anthropic 形态，否则不要走 Messages。 |
+| **new-api / one-api** | Anthropic 上游 = origin（Messages）；OpenAI 上游 = `origin/v1`（Chat） | 同一通道混用两种协议。目前没有官方 new-api 渠道 PR，按通用 sidecar 配置。 |
+
+Claude Code、Grok Build、Codex 改的是**你本机项目**，用的是**它们自己的工具**。网关只跑模型。Cursor SDK 的 `cwd` 是按凭证隔离的空目录，所以模型有时会吐出那个绝对路径。优先写相对路径，或写你的真实项目路径。
+
+**Claude 1M 上下文。** Cursor 实时目录目前会为 Claude Sonnet 4.6、Fable 5 等模型暴露 `context=1m`。本网关保留精确公开模型 ID，并把官方 SDK 的 `{id,value}` 参数原样转发。它不会自己发明上下文窗口，也不会模拟 Anthropic 长上下文计费。1M 目录路径已经核验，但公开回执不包含人为构造的一百万 token 压测。
+
+**网页 / 网络搜索。** 客户端自己的搜索工具仍在客户端执行。如果 Claude Code、Grok Build 或 Codex 暴露了本机网页 / 网络搜索工具，网关会把它当成普通调用方工具回传结果。Cursor ambient 的 `webSearch` / `webFetch` 会被拒绝。托管的 OpenAI `web_search` 会被拒绝。**经 Cursor 路由的 Grok 不会暴露 xAI 原生 `x_search`。** 那个工具在 xAI 自己的 API 上，不在这条 Cursor SDK 路径上。
+
+兼容性证据：
+
+- Claude Code：Sonnet 4.6 与 Fable 5 的完整宿主机 Messages 矩阵已通过，覆盖文本、SSE、单工具、并行工具、多轮工具、replay、cache 读写和 completed resume。公开矩阵中的 Fable 5 Claude Code 形态请求已通过；之后真实 Claude Code 运营探测也完成了 Sonnet 4.6 会话并调用本机工作区工具。
+- Grok Build：Responses 适配对 Grok 的具名工具选择、usage 明细对象、已知的加密 reasoning include 有 contract 测试。一次本地运营探测用真实 Grok Build Responses 会话写下了工作区标记。同样只证明接通 + 本机工具。
+- Codex：有 Responses contract 套件。本仓库没有 Codex 真实客户端回执。
+
+## 能力矩阵
+
+`GET /health` 的能力位只表示网关实现了该路径，不是真实模型验收章。二进制里的 `verification.live_smoke` 保持 `false`。
+
+| 能力 | 状态 | 边界 |
+|---|---|---|
+| Anthropic Messages 文本 + SSE | 已实现；Sonnet 4.6、Fable 5、Composer 2.5、Grok 4.6 xhigh 有 live 抽样 | 有日期的宿主机回执：[docs/evidence/2026-08-15-live-smoke.md](docs/evidence/2026-08-15-live-smoke.md) |
+| OpenAI Chat Completions | 协议适配；已有 contract 测试 | Health 标记为 `contract_tested_unverified_live`。没有 live Chat 矩阵。 |
+| OpenAI Responses | 协议适配；已有 contract 测试 | 同样的 health 标记。Grok Build 接通有本地探测。Codex 未做 live 认证。 |
+| Claude `count_tokens` | 本地保守估算 | 响应头 `x-cursor-sdk2api-token-count: estimated`。不启动 SDK Run。不计费。 |
+| Claude 1M 上下文 | 目录 / 参数透传 | 只转发精确 Cursor ID 和官方 SDK 参数。本仓库没有 1M token 验收。 |
+| Thinking / reasoning | 已实现；有 contract 测试 | 真实模型上的 thinking 粒度仍是独立 gate。Grok 的加密 reasoning include 会接受并省略。 |
+| 图片 | 已实现；有 contract 测试 | 只接受 base64。远程 `image_url` 返回 `422`。 |
+| 调用方工具经 custom MCP | 已实现 | 请求里的 `tools[]` → SDK `local.customTools`。有调用方工具时 allowlist 为 `["mcp"]`，否则 `[]`。 |
+| 同轮并行工具 | 已实现；Claude / Composer 有 live 抽样 | 公开回执里 Grok 同轮两工具选择**不可重复**。不要当成保证行为。 |
+| 多轮工具续轮 | 已实现；有 live 抽样 | 最新 user turn 只能是 `tool_result` / `function_call_output`。文本和结果混在一起会 `422`。 |
+| 客户端网页 / 网络搜索 | 仅当**客户端**拥有该工具 | 按普通调用方工具映射。网关不会白送搜索。 |
+| Cursor ambient `shell` / `read` / `edit` / `task` / `webSearch` / `webFetch` | 拒绝 | 空 workspace。`settingSources: []`。 |
+| xAI `x_search` | **不可用** | 经 Cursor 路由的 Grok 仍然是 Cursor。需要 `x_search` 请走 xAI 原生 API。 |
+| 托管 OpenAI 工具（`web_search`、`file_search`、`computer`、`shell`、`apply_patch`） | Fail closed | `422` |
+| Responses `previous_response_id` / `store=true` / conversation | Fail closed | 续轮用 `function_call_output.call_id` 或 `x-cursor-session-id`。 |
+| 进程内 live 工具续轮 | 进程内 Promise | 一个 owner 进程。Pending callback 不能按原样序列化。 |
+| Pending 工具重启恢复 | 已实现；fake SDK 集成测试已覆盖 | 精确匹配 credential / model / 参数 / tool-id 批次 / 工具目录后，走 `Agent.resume` + `local.force=true`。已发布的 2026-08-15 live-smoke 仍记录 `409 cursor_session_lost`（当时 runner 按旧的 fail-closed 路径验收）。 |
+| 已完成 follow-up resume | 已实现；有 live 抽样 | `x-cursor-session-id`，在 `SESSION_TTL_MS` 内。 |
+| Cursor Dashboard 额度 | 已实现 | 同一把 User API Key。不需要 Cookie、Team Admin Key 或 OAuth 导入。缺失用量返回 `partial`，不会伪造为零。 |
+| 出站 HTTP(S) 代理 | 已实现；容器内探测过 | 两条 SDK 数据通路。SOCKS / PAC fail closed。 |
 
 ## 快速开始
 
 需要 Node.js 22.19 或更新版本。
 
 ```bash
+git clone https://github.com/Sunnyender-org/cursor-sdk2api.git
+cd cursor-sdk2api
 npm ci
 npm run build
 export AUTH_MODE=byok
 node dist/index.js
 ```
 
-打开 `http://localhost:8080/console/` 使用可选运维控制台。Cursor 账号文件保存在服务端
-`STATE_DIR/auths`，目录权限为 `0700`、文件权限为 `0600`，刷新页面或重启网关后仍会保留。
+打开 [http://localhost:8080/console/](http://localhost:8080/console/)。在控制台里添加 Cursor API Key，或在每个请求里携带。
 
 ```bash
 curl -s localhost:8080/health
@@ -52,7 +117,7 @@ curl -s localhost:8080/v1/messages \
   -d '{"model":"composer-2.5","max_tokens":64,"messages":[{"role":"user","content":"hello"}]}'
 ```
 
-Docker：
+### Docker
 
 ```bash
 docker build -t cursor-sdk2api:local .
@@ -63,14 +128,14 @@ docker run --rm -p 8080:8080 -e AUTH_MODE=byok cursor-sdk2api:local
 
 完整配置面见 [`.env.example`](.env.example)。不要提交真实密钥。
 
-## 出站代理
+### 出站代理
 
-官方 SDK 不会自动继承宿主机代理。设置受支持的代理变量后，网关会同时接管 **两条** SDK 数据通路：
+官方 SDK 不会自己继承宿主机代理。设置受支持的代理变量后，网关会同时接管 **两条** SDK 数据通路：
 
-- 本地 Agent 切换到 HTTP/1.1，并通过 `proxy-agent` 出站
-- 模型目录、账号与 Cursor Dashboard 用量查询走 Undici 的环境代理 dispatcher
+- 本地 Agent 切换到 HTTP/1.1，经 `proxy-agent` 出站
+- 模型目录、账号与 Cursor Dashboard 查询走 Undici 的环境代理 dispatcher
 
-`HTTP_PROXY`、`HTTPS_PROXY`、`ALL_PROXY` 与 `NO_PROXY` 的大小写形式均接受。代理 URL 必须是 `http://` 或 `https://`。SOCKS / PAC 会 fail closed，因为两条 SDK 通路无法一致支持它们。未配置代理时，Agent 保留官方 HTTP/2 传输。
+`HTTP_PROXY`、`HTTPS_PROXY`、`ALL_PROXY` 与 `NO_PROXY` 的大小写形式均接受。代理 URL 必须是 `http://` 或 `https://`。SOCKS / PAC 会 fail closed。未配置代理时，Agent 保留官方 HTTP/2 传输。
 
 `/health` 只报告 `network.proxy_configured`、`network.agent_transport` 与 `network.fetch_transport`，从不返回代理 URL 或认证信息。
 
@@ -92,7 +157,108 @@ docker run --rm -p 8080:8080 \
   cursor-sdk2api:local
 ```
 
-不要把带 userinfo 的代理 URL 写进 compose 或文档。优先使用无凭据的回环地址，或把凭据放在单独保护的环境里。
+不要把带 userinfo 的代理 URL 写进 compose 或文档。
+
+## 客户端配置
+
+网关不在本机回环时，换成实际 origin。BYOK 模式下密钥是 Cursor API Key；managed 模式下是 `GATEWAY_ACCESS_KEY`。
+
+### Claude Code → Messages
+
+```bash
+export ANTHROPIC_BASE_URL=http://127.0.0.1:8080
+export ANTHROPIC_AUTH_TOKEN="$CURSOR_API_KEY"
+export ANTHROPIC_MODEL=claude-sonnet-4-6
+claude
+```
+
+Claude Code 发送 `x-api-key`。网关同时接受它和 `Authorization: Bearer`。`ANTHROPIC_BASE_URL` 填 origin（不要带 `/v1`）；Claude Code 会自己拼 `/v1/messages`。
+
+若账号开了 Privacy Mode，或属于 Team / Enterprise，Fable 5 可能要先在 [Cursor Dashboard](https://cursor.com/dashboard/restricted_models/claude-fable-5) 批准数据保留政策，才会出现在官方目录。
+
+### Grok Build → Responses
+
+```toml
+[models]
+default = "cursor-gw"
+
+[model.cursor-gw]
+name = "cursor-sdk2api"
+base_url = "http://127.0.0.1:8080/v1"
+api_key = "<cursor-api-key>"
+model = "grok-4.6"
+api_backend = "responses"
+```
+
+Grok 本机的 `web_search` / `web_fetch`（若你没关掉）跑在 **Grok 进程里**，再以普通 function 结果回来。它们不是 Cursor ambient 工具，也不是 xAI `x_search`。
+
+### Codex / OpenAI Responses
+
+```toml
+model = "composer-2.5"
+model_provider = "cursor-sdk2api"
+
+[model_providers.cursor-sdk2api]
+name = "cursor-sdk2api"
+base_url = "http://127.0.0.1:8080/v1"
+wire_api = "responses"
+env_key = "CURSOR_API_KEY"
+```
+
+或用 OpenAI SDK：
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:8080/v1", api_key=CURSOR_API_KEY)
+client.responses.create(model="composer-2.5", input="hello")
+```
+
+不要发送 `previous_response_id`。Pending 工具续轮只接受末尾的 `function_call_output`，且 `call_id` 对得上当前 live tool id。已完成 follow-up 走 `x-cursor-session-id`。若你的 Codex 版本坚持要用 store 里的 response id，本网关会 422；改走 Chat Completions。
+
+### OpenAI Chat Completions
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:8080/v1", api_key=CURSOR_API_KEY)
+client.chat.completions.create(
+    model="composer-2.5",
+    messages=[{"role": "user", "content": "hello"}],
+)
+```
+
+### new-api / 通用 SDK sidecar
+
+```text
+Base URL（Anthropic 上游）：  http://<gateway-host>:8080
+Base URL（OpenAI 上游）：     http://<gateway-host>:8080/v1
+API key：                    Cursor Key（BYOK）或 GATEWAY_ACCESS_KEY（managed）
+模型发现：                   GET /v1/models
+```
+
+不要把 `@cursor/sdk` 嵌进另一个网关进程。本进程保持 sidecar。
+
+## 端点
+
+| 方法 | 路径 | 认证 | 说明 |
+|---|---|---|---|
+| `GET` | `/console/` | 打开页面不需要 | 可选 BF Labs 运维控制台。 |
+| `GET` / `POST` / `DELETE` | `/v0/management/accounts` | **v0.1 无认证** | 增删查持久化的 Cursor Key，并返回原始密钥。只允许可信网络或外层认证代理。 |
+| `GET` | `/health` | 无 | 构建版本、SDK 版本、就绪状态、能力位、传输模式、`verification`。不含账号数据、密钥或代理 URL。 |
+| `GET` | `/v1/models` | 需要 | 实时 `Cursor.models.list()`，保留精确公开 ID。不可用时返回空列表并给出 reason。 |
+| `GET` | `/v1/account` | 需要 | `Cursor.me()` 身份 + 同一把 User API Key 查 Dashboard 当前周期用量。 |
+| `POST` | `/v1/messages/count_tokens` | 需要 | 给 Claude Code 上下文管理用的本地估算。 |
+| `POST` | `/v1/messages` | 需要 | Anthropic Messages 文本、SSE、调用方工具、并行工具、多轮续轮、进程内 replay。 |
+| `POST` | `/v1/chat/completions` | 需要 | 同一套 Run 引擎上的 OpenAI Chat 适配。 |
+| `POST` | `/v1/responses` | 需要 | 同一套 Run 引擎上的 OpenAI Responses 适配。 |
+
+默认 **API Compatibility Profile**（三条推理端点共用）：
+
+- 请求里的 `tools[]` 映射为 SDK `local.customTools`
+- 存在调用方工具时内置 allowlist 为 `["mcp"]`，否则为 `[]`
+- 拒绝 Cursor ambient 能力（`shell`、`read`、`edit`、`task`、`webSearch`、`webFetch`）
+- `settingSources: []`，并使用空 workspace。不会隐式带上调用方仓库
 
 ## 认证
 
@@ -100,60 +266,63 @@ docker run --rm -p 8080:8080 \
 
 **Managed（可选）。** 进程持有 `CURSOR_API_KEY`。客户端发送不同的 `GATEWAY_ACCESS_KEY`。Health 不会暴露 managed 模式下的 Cursor 身份。
 
-**控制台账号。** 本地控制台在 `STATE_DIR/auths` 增删查 Cursor 账号文件。这些文件包含原始 Cursor API Key，必须作为敏感信息保护。v0.1 的控制台管理接口没有单独 Access Key，请只在可信本地网络使用，或在外层加认证代理。
+**控制台账号。** 控制台把 Cursor 账号文件写到 `STATE_DIR/auths`（目录 `0700`、文件 `0600`，明文密钥）。刷新页面会从 `/v0/management/accounts` 重新加载这些密钥。该管理接口没有单独 Access Key。
 
 禁止：浏览器 Cookie、Desktop/CLI 私有凭据库、邮箱密码登录、refresh token 导入，以及把密钥放进 URL、模型名或 tool ID。
 
-## API 示例
+## 运维控制台与额度
 
-非流式 Messages 会返回 assistant 消息以及 `cursor_session_id`（`ses_...`）。后续 completed follow-up 把它放进 `x-cursor-session-id`：
+`/console/` 是同一 Node 进程提供的静态 Vite 资源，不需要第二个生产服务。
 
-```bash
-curl -s localhost:8080/v1/messages \
-  -H "Authorization: Bearer $CURSOR_API_KEY" \
-  -H "content-type: application/json" \
-  -H "x-cursor-session-id: ses_replace_me" \
-  -d '{"model":"composer-2.5","max_tokens":64,"messages":[{"role":"user","content":"continue"}]}'
+- 概览：health、SDK 版本、传输模式
+- 账号：增删查持久化的 Cursor Key
+- 额度：当前周期花费、剩余 included 用量、套餐元数据、模型族占比（Dashboard 返回时才有）
+- 试跑：Messages、Chat Completions、Responses
+- 接入：与本 README 相同的客户端配方
+- 中 / 英、浅色 / 深色
+
+`/v1/account` 会用同一把 User API Key 做两件事：官方 `Cursor.me()` 取身份，再用短期 Dashboard access token 调 `GetCurrentPeriodUsage` 和 `GetPlanInfo`。不需要 Cookie、Team Admin Key 或 OAuth Token。Dashboard 不可用时，身份仍可能返回，响应为 `status: partial` 并带明确 reason。缺失用量会被省略，不会编成 0。
+
+## 架构与工具归属
+
+```
+Claude Code | Grok Build | Codex | OpenAI SDK | new-api | curl
+        |
+        v
+HTTP /v1/messages | /v1/chat/completions | /v1/responses
+        |
+        v
+协议解析（Chat / Responses -> 规范 ParsedMessages）
+        |
+        v
+RunCoordinator
+  SessionRegistry   （fingerprint、model、tool_use_id、TTL）
+  ToolBridge        （调用方工具 -> local.customTools）
+  EventPump         （唯一的 run.stream() consumer）
+  协议写出           （Anthropic SSE | Chat data: | Responses 事件）
+        |
+        v
+官方 @cursor/sdk  （Agent / Run / Jsonl store / models.list / me）
 ```
 
-Chat Completions 使用同一个 session header。非流式响应会返回 `cursor_session_id` 和 `x-cursor-session-id`。末尾的 `role:tool` 消息会继续同一个 pending SDK run：
+Chat Completions 和 Responses 没有第二套 session 引擎。只有解析器和 HTTP 写出层不同。
 
-```bash
-curl -s localhost:8080/v1/chat/completions \
-  -H "Authorization: Bearer $CURSOR_API_KEY" \
-  -H "content-type: application/json" \
-  -d '{"model":"composer-2.5","messages":[{"role":"user","content":"hello"}]}'
-```
+这里有两种完全不同的「工具」。混为一谈，就会幻想出 `x_search` 和静默 shell。
 
-`n` 只能是 `1` 或省略。远程 `image_url` 会被 `422` 拒绝，需要 base64 data URL。流式帧是 OpenAI `data:` chunk（每帧后空一行，没有 Anthropic event 名），并以 `data: [DONE]` 结束。`stream_options.include_usage=true` 会在 `[DONE]` 前多发一个 `choices=[]` 的 usage chunk。
+| 归属 | 跑什么 | 跑在哪里 |
+|---|---|---|
+| Claude Code / Grok / Codex | 它们的本机工具：读、改、shell，以及该客户端若开启的网页 / 网络搜索 | 你的项目目录，在客户端进程里 |
+| 本网关 | 模型推理 + 工具*选择* | `@cursor/sdk` Agent，cwd 为空目录 |
+| Cursor ambient 工具 | `shell`、`read`、`edit`、`task`、`webSearch`、`webFetch` | **拒绝** |
+| xAI | `x_search` 及其他 xAI 原生托管工具 | **不在这条路径上** |
 
-`/v1/responses` 使用同一套 Run 引擎。已完成 follow-up 仍走 `x-cursor-session-id`。pending 工具续轮只接受最新 `input` 全是 `function_call_output`，并且 `call_id` 对上当前 live tool id。`previous_response_id` 会被拒绝；这不是无状态的 OpenAI store。
+存在调用方工具时，prompt 会告诉模型：custom MCP 工具在 API 调用方环境执行，SDK cwd 不是权威路径。
 
-```bash
-curl -s localhost:8080/v1/responses \
-  -H "Authorization: Bearer $CURSOR_API_KEY" \
-  -H "content-type: application/json" \
-  -d '{"model":"composer-2.5","input":"hello"}'
-```
+## 协议说明
 
-流式事件使用 Responses 事件名（`response.created` … `response.completed`）。出错时发 Responses `error` 事件，不会发假的 `response.completed`。托管工具、`store=true`、background、conversation 和未知 include expansion 会 fail closed。Grok 可选的 `reasoning.encrypted_content` include 会接受但省略。
+非流式 Messages 会返回 assistant 消息以及 `cursor_session_id`（`ses_...`）。已完成 follow-up 把它放进 `x-cursor-session-id`。
 
-`function_call_output.output` 接受字符串或文本 content part 数组。图片/文件型工具结果在能够无损映射到 SDK 前会以 `422` fail closed，不会静默转成 JSON 文本。
-
-保持公开目录中的模型 ID 不变。例如 Grok 4.6 xhigh：
-
-```json
-{
-  "model": "grok-4.6",
-  "reasoning_effort": "xhigh",
-  "max_tokens": 64,
-  "messages": [{ "role": "user", "content": "hello" }]
-}
-```
-
-高级调用方可通过 `cursor_model_params` 传入已校验的官方 SDK `{id,value}` 参数。同一 session 上显式改参数会得到 `409 cursor_session_conflict`。
-
-工具续轮使用同一进程内的 Agent/Run。最新 user turn 只能包含 `tool_result` 块：
+工具续轮使用同一进程内的 Agent/Run。最新 user turn 只能包含 `tool_result` 块，按 `tool_use_id` 匹配（顺序不是权威依据）。
 
 ```json
 {
@@ -174,94 +343,59 @@ curl -s localhost:8080/v1/responses \
 }
 ```
 
-对于 `/v1/messages`，`max_tokens` 会被接受，以便 Claude Code 形态的请求能解析。SDK Harness 没有精确的 max-token 强制执行，网关也不会模拟一层。工具选择会映射成 Harness 指令：Messages 支持 `auto` / `any` / 指定 `tool`；Chat 与 Responses 支持 `auto` / `required` / 指定 `function`。串行工具标志会生效；`tool_choice=none` 仍然 fail closed。
+Chat Completions 使用同一个 session header。末尾的 `role:tool` 消息会继续同一个 pending run。`n` 只能是 `1` 或省略。流式帧是 OpenAI `data:` chunk，并以 `data: [DONE]` 结束。
 
-错误体：
+Responses 的 pending 工具续轮只接受最新 `input` 全是 `function_call_output`，并且每个 `call_id` 对上当前 live tool id。`function_call_output.output` 接受字符串或文本 part。图片 / 文件型工具结果在能无损映射到 SDK 之前会 `422`。流式事件使用 Responses 事件名（`response.created` … `response.completed`）。出错时发 Responses `error` 事件，不会发假的 `response.completed`。
+
+保持公开目录中的模型 ID 不变。例如 Grok 4.6 xhigh：
 
 ```json
 {
-  "type": "error",
-  "error": { "type": "invalid_request", "message": "..." },
-  "request_id": "req_..."
+  "model": "grok-4.6",
+  "reasoning_effort": "xhigh",
+  "max_tokens": 64,
+  "messages": [{ "role": "user", "content": "hello" }]
 }
 ```
 
+高级调用方可通过 `cursor_model_params` 传入已校验的官方 SDK `{id,value}` 参数。同一 session 上显式改参数会得到 `409 cursor_session_conflict`。
+
+`max_tokens` 会被接受，以便 Claude Code 形态的请求能解析。SDK Harness 没有精确的 max-token 强制执行，网关也不会模拟一层。工具选择会映射成 Harness 指令：Messages 支持 `auto` / `any` / 指定 `tool`；Chat 与 Responses 支持 `auto` / `required` / 指定 `function`。串行工具标志会生效。`tool_choice=none` 仍然 fail closed。
+
+`temperature`、`top_p`、`stop_sequences` 会被接受，但**不会映射**到 `@cursor/sdk`。
+
+默认工具批处理 debounce 是从最近一次 callback 起 1500ms（`TOOL_BATCH_SETTLE_MS`）。真实 SDK 探针观察到，同一 assistant turn 里 Claude callback 可能相隔超过 1 秒。
+
+Usage：中间工具轮返回零 usage，并带 `usage_deferred: true`。累计 SDK usage 只在最终轮通过 `run.wait()` 确认一次。cache 与 reasoning 字段仅在 SDK 真正返回时出现。
+
 公开错误类型：`invalid_request`、`authentication_error`、`forbidden`、`cursor_session_conflict`、`cursor_session_lost`、`rate_limited`、`cursor_empty_turn`、`cursor_upstream_error`、`cursor_timeout`。
 
-## 原生工具闭环
+## 安全与限制
 
-broker 在进程内持有一个 SDK Agent/Run。
+把 v0.1 当成可信本地 sidecar。
 
-1. 第一次请求可以在同一 assistant turn 返回 N 个 `tool_use` 块。
-2. 下一次请求的最新 user turn 只能发送 `tool_result` 块。
-3. 结果按 `tool_use_id` 匹配，顺序不是权威依据。
-4. 错误、缺失、跨 session 或 duplicate-different ID 都会 fail closed。
-5. duplicate-same 结果会 replay 已存储的 turn，不会再次 resolve。
-6. HTTP sink 会在 deferred tool Promise resolve 之前挂上。
-7. `run.stream()` 只有一个 consumer。
-
-默认工具批处理 debounce 是从最近一次 callback 起 1500ms（`TOOL_BATCH_SETTLE_MS`）。真实 SDK 探针观察到，同一 assistant turn 里 Claude callback 可能相隔超过 1 秒；收到第一个就封包会丢掉后续 pending 调用。
-
-pending callback 是普通内存 Promise，不能跨进程序列化。
-
-## Usage 与 cache
-
-- 中间工具轮返回零 usage，并带 `usage_deferred: true`。
-- 累计 SDK usage 只在最终轮通过 `run.wait()` 确认一次。
-- cache 字段仅在 SDK 真正返回时出现。缺失字段会被省略，不会编造。
-
-## 状态、resume 与多实例
-
-MVP 只在创建该 live run 的进程里持有它。
-
-- 蓝绿和多实例部署需要排空连接，并对 session 做粘性归属。
-- 进程重启后，如果 credential、model、模型参数、完整 tool-id 批次和工具目录都匹配 owner-only lineage，未完成的工具续轮可以恢复。
-- 网关不会新建 Agent 来假装原来的 pending Run 已经恢复。
-
-带 `x-cursor-session-id` 的 completed follow-up，在 `SESSION_TTL_MS` 内且 credential / model / 显式模型参数匹配时，可以通过 `Agent.resume` 续聊。Pending 工具恢复复用同一个 SDK store，并使用 `local.force=true`；真实 kill/restart 验收通过后，health 报告 `pending_tool_restart_resume=true`。
-
-`STATE_DIR` 存放：
-
-- 可选的控制台账号文件：`$STATE_DIR/auths`（`0700` / `0600`；明文敏感信息）
-- 官方 JSONL SDK store：`$STATE_DIR/sdk-store/<credential-fingerprint>`
-- 仅属主可读写的 lineage 元数据：`$STATE_DIR/lineage`（`0700` / `0600`）
-
-本机 / 开发默认是 `$TMPDIR/cursor-sdk2api/state`。镜像和 compose 默认是 `/data`。lineage 只存 resume 元数据（session id、SDK agent id、fingerprint、model、显式参数、state、pending tool id/name、可选 result digest、时间戳）。它不存 API Key、prompt、工具输入或工具结果。assistant replay 正文不会落盘。
-
-BYOK 凭据共享进程容量上限，但官方 SDK store 和空 workspace 按 credential fingerprint 分区。这是进程内租户隔离，不是“可抵御恶意多租户托管”的声明。
-
-开发默认值：全局 4 个 active run、每个凭据 2 个、session TTL 30 分钟、replay TTL 10 分钟、run deadline 60 分钟。active-run 限制适用于 create、completed follow-up 和持久化 resume。drain 期间仍接受等待中的 `tool_result`。
-
-## 现状与证据
-
-v0.1 已实现 Messages 文本/SSE、客户端 customTools/MCP、同轮并行工具、多轮 continuation、进程内 replay、租户/模型隔离、completed Agent resume，以及精确的 pending 工具重启恢复。Chat Completions 和 Responses 与 Messages 共用同一个 coordinator。运维控制台 playground 可以测试三种协议。
-
-脱敏、不含秘密的验收摘要见 [`docs/evidence/2026-08-15-live-smoke.md`](docs/evidence/2026-08-15-live-smoke.md)。这份 receipt 是有日期的本地样本，不能保证每个凭据、地区或镜像都一样：
-
-- 宿主机上 Claude Sonnet 4.6 与 Fable 5 通过了要求的代理矩阵，包括并行工具和 Claude Code 形态的 Fable 请求。
-- Composer 2.5 通过了要求的宿主机矩阵，包括同轮并行选择。
-- Grok 4.6 xhigh 通过了文本、SSE、单工具、多轮、replay、pending 重启 fail-closed 和 completed resume。该样本里同轮并行选择是 **模型非确定** 的，**不能**当作保证行为。
-- Node 22 容器证明两条 SDK 数据通路都会走已配置的 HTTP(S) 代理，代理不可达时会失败。Fable 容器的并行/上游成功 **并非** 完全可重复，因此 **不会** 宣传成全绿容器矩阵。
-- 运行时 `/health.verification.live_smoke` 保持 `false`。二进制无法推断另一次部署继承了这份 receipt。
-
-thinking 和 image 块已实现并有 contract 测试。真实模型上的 thinking/image 粒度仍是独立模型 gate。
-
-## 已知限制
-
-- 运行时必须使用官方 `@cursor/sdk`。其自身许可证和 Cursor Terms 仍然适用。见 [NOTICE.md](NOTICE.md)。
+- `/v0/management/accounts` 没有 Access Key，并返回原始 Cursor Key。
+- `STATE_DIR/auths` 下的账号 JSON 是明文。优先使用加密卷。
+- `STATE_DIR/sdk-store` 是官方 SDK 的对话 / checkpoint store。本网关不审计这些文件。
+- `STATE_DIR/lineage` 只存 resume 元数据（session id、agent id、fingerprint、model、参数、pending tool id/name、可选 result digest）。不存 API Key、prompt 或工具载荷。
+- Live 工具 callback 是内存 Promise。多实例和蓝绿部署需要排空连接，并对 session 做粘性归属。
+- 崩溃后的 pending 恢复要求同一份 `STATE_DIR`，以及精确的身份 / 目录 / 结果批次匹配。不匹配就是 `409`，不会静默新建 Agent。重启后的 duplicate-same 没有持久化的 assistant 正文。
+- 不要在共享主机上开启 payload logging，也不要设置 `DEBUG=*` 或 `DEBUG=proxy-agent`。
+- 面向公网仍需要 TLS、认证代理、加密状态、监控，以及明确的威胁模型。进程内 fingerprint 隔离不是「可抵御恶意多租户托管」。
+- 官方 `@cursor/sdk` 许可证和 Cursor Terms 仍然适用。见 [NOTICE.md](NOTICE.md)。
 - 生产依赖 `npm audit --omit=dev`（2026-08-15）在 SDK 树中报告 3 个传递性发现：`undici`（high），以及 `@connectrpc/connect-node` / `@cursor/sdk`（moderate）。`fixAvailable` 为 false。不要执行破坏性的 `npm audit fix`。
-- Cursor Dashboard 用量链路会先用 User API Key 换取短期 dashboard access token，再调用 `GetCurrentPeriodUsage` 与 `GetPlanInfo`。该控制面不可用时，身份仍会返回，`/v1/account` 以明确 reason 降级为 `partial`。
-- `@cursor/sdk` 没有 tokenizer preflight API，因此 `count_tokens` 是本地估算；最终 SDK usage 才是外部计费的权威值。
-- 跨机器恢复仍要求共享同一份持久化 SDK/lineage 状态；没有这份状态的无状态副本会 fail closed。
-- 带凭据的真实模型测试需要显式启用，不属于默认 CI。
 
 尚未实现：
 
-- Responses 的 `previous_response_id` 重建、`store=true`、background、conversation、include 展开，以及托管内置工具（`web_search`、`file_search`、`computer`、`shell`、`apply_patch`）
+- Responses 的 `previous_response_id` 重建、`store=true`、background、conversation、未知 include 展开、托管内置工具
+- xAI 原生 `x_search`
 - Cursor Agent Profile（`/v1/agents`、原生 shell/edit、plan mode）
 - 分布式 session 归属 / Redis / Postgres
+- 官方 new-api 渠道类型
 
-## 开发
+开发默认值：全局 4 个 active run、每个凭据 2 个、session TTL 30 分钟、replay TTL 10 分钟、run deadline 60 分钟。drain 期间仍接受等待中的 `tool_result`。本机默认 `STATE_DIR` 是 `$TMPDIR/cursor-sdk2api/state`。镜像和 compose 默认是 `/data`。
+
+## 测试、证据、现状
 
 ```bash
 npm ci
@@ -270,10 +404,9 @@ npm test
 npm run build
 ```
 
-`npm run dev` 会先构建一次控制台再启动网关。只调试 UI 时可运行
-`npm run dev:web`；只有开发者明确配置代理时，Vite 才会把 API 请求转发到网关。
+`npm run dev` 会先构建一次控制台再启动网关。`npm run dev:web` 只跑 UI。
 
-测试注入确定性 fake SDK，从不读取真实 Cursor 凭据。GitHub Actions CI 见 [`.github/workflows/ci.yml`](.github/workflows/ci.yml)，会跑 typecheck、测试、构建和 `docker build`。
+测试注入确定性 fake SDK，从不读取真实 Cursor 凭据。CI 见 [`.github/workflows/ci.yml`](.github/workflows/ci.yml)，会跑 typecheck、测试、构建和 `docker build`。
 
 显式启用的 live 矩阵（不是默认 CI，也不会被 `npm test` 执行）：
 
@@ -282,7 +415,17 @@ npm run build
 CURSOR_LIVE_SMOKE=1 CURSOR_API_KEY=... npm run live:smoke
 ```
 
-runner 只绑定回环，在临时目录写脱敏 receipt，并且从不记录密钥、prompt 或工具载荷。见 [`scripts/live-smoke/README.md`](scripts/live-smoke/README.md)。
+runner 只绑定回环，并写脱敏 receipt。见 [`scripts/live-smoke/README.md`](scripts/live-smoke/README.md)。
+
+已发布样本：[`docs/evidence/2026-08-15-live-smoke.md`](docs/evidence/2026-08-15-live-smoke.md)。有日期、绑定特定凭据，不能被另一个二进制继承。
+
+- 宿主机上 Claude Sonnet 4.6 与 Fable 5 通过了要求的代理 Messages 矩阵，包括并行工具和 Claude Code 形态的 Fable 请求。
+- Composer 2.5 通过了同一套宿主机矩阵，包括同轮并行选择。
+- Grok 4.6 xhigh 通过了文本、SSE、单工具、多轮、replay、pending 重启 fail-closed（当时为 `409`）和 completed resume。同轮并行在一次运行里出现过、后来又没选满；不要宣传成保证行为。
+- Node 22 容器证明两条 SDK 数据通路都会走已配置的 HTTP(S) 代理，代理不可达时会失败。Fable 容器的并行 / 上游成功并非完全可重复。
+- 之后的本地运营探测（未作为公开回执入库）接通了真实 Claude Code（Sonnet 4.6）和 Grok Build（Responses，Grok 4.6），并确认这些客户端用自己的工作区文件工具写了标记。
+
+当前是 v0.1。Chat Completions 和 Responses 是 Messages Run 引擎上的适配层。npm 发布、GHCR digest 和 new-api 上游 PR 都是后续独立决定。
 
 ## 文档
 
@@ -292,30 +435,9 @@ runner 只绑定回环，在临时目录写脱敏 receipt，并且从不记录�
 | [docs/PROTOCOL_COMPATIBILITY.md](docs/PROTOCOL_COMPATIBILITY.md) | 端点与内容块支持矩阵 |
 | [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) | 本机、Docker、drain 与升级 |
 | [docs/SECURITY.md](docs/SECURITY.md) | 凭据、日志与威胁说明 |
-| [docs/NEW_API_INTEGRATION.md](docs/NEW_API_INTEGRATION.md) | 把网关当作通用 Anthropic 上游使用 |
-| [docs/DELIVERY_PLAN.md](docs/DELIVERY_PLAN.md) | 公开路线图与后续阶段 |
+| [docs/NEW_API_INTEGRATION.md](docs/NEW_API_INTEGRATION.md) | 通用 Anthropic / OpenAI sidecar |
+| [docs/DELIVERY_PLAN.md](docs/DELIVERY_PLAN.md) | 公开路线图 |
 | [CHANGELOG.md](CHANGELOG.md) | v0.1 说明 |
-
-在存在已发布镜像 digest 之前，把 Claude Code、OpenCode 或通用 Anthropic 客户端指向 `http://<gateway-host>:8080`，密钥用 Cursor key（BYOK）或 gateway access key（managed）。不要把 `@cursor/sdk` 嵌进另一个网关进程。
-
-### 客户端对应端点
-
-| 客户端 | 用这个 | 不要用 |
-|---|---|---|
-| Claude Code | `ANTHROPIC_BASE_URL` → `POST /v1/messages` | Chat Completions |
-| Grok Build | 自定义模型 `api_backend = "responses"` → `POST /v1/responses` | Messages。若客户端带 `previous_response_id`，本网关会 422，再退回 `chat_completions` |
-| OpenAI SDK / 通用 Chat | `base_url` `…/v1` → `POST /v1/chat/completions` | 除非客户端是 Anthropic 形态，否则不要走 Messages |
-| new-api | Anthropic 上游 = Messages；OpenAI 上游 = Chat | 同一通道混用两种协议 |
-
-Grok Build / Claude Code 改的是**你本机项目**，用的是它们自己的工具。网关只提供模型推理。Cursor SDK 的 cwd 是按凭证隔离的空目录，所以模型有时会吐出那个绝对路径。写相对路径或你的项目路径就能改本地文件。BeefAPI 的 Cursor 通路也是同一件事。
-
-## 安全
-
-- 不要在共享主机上开启 payload logging。
-- 不要在共享主机上设置 `DEBUG=*` 或 `DEBUG=proxy-agent`；第三方传输日志可能打印代理配置。
-- 把 `STATE_DIR` 当作仅属主可访问的敏感状态。官方 SDK store 可能包含对话和 checkpoint 数据；本网关不会审计这些文件。
-- 面向公网部署仍需要 TLS、访问控制、加密状态、监控，以及明确的运营威胁模型。
-- 默认日志可以包含 request id、model id、stream 标志、status、pending 数量和最终数值 usage。不得包含密钥、Cookie、prompt、thinking、工具 schema、工具参数或工具结果。
 
 ## 许可与贡献
 


### PR DESCRIPTION
## Summary

- Rewrite the English and Simplified Chinese READMEs as a launch-oriented gateway guide.
- Lead with the verified Claude Code, Claude 1M catalog passthrough, Grok Build, Codex/Responses, and client-owned tool paths.
- Document that Cursor-routed Grok does not provide xAI `x_search`, while caller-owned web/network tools remain supported.
- Keep protocol, security, restart, quota, and live-evidence boundaries explicit.

## Validation

- `git diff --check`
- README local-link and sensitive-string checks
- `npm run typecheck`
- `npm test` (153/153)
- `npm run build`
