### PR TITLE
Add external new-api delivery and GHCR release pipeline

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,15 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+  categories:
+    - title: Breaking changes
+      labels: [breaking-change]
+    - title: Features
+      labels: [enhancement, feature]
+    - title: Fixes
+      labels: [bug, fix]
+    - title: Documentation and maintenance
+      labels: [documentation, dependencies, chore]
+    - title: Other changes
+      labels: ["*"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,104 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+  attestations: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Verify tag matches package version
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected="v$(node -p "require('./package.json').version")"
+          test "${GITHUB_REF_NAME}" = "$expected" || {
+            echo "tag ${GITHUB_REF_NAME} does not match package version $expected" >&2
+            exit 1
+          }
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22.19
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm test
+      - run: npm run build
+      - name: Secret scan
+        run: >-
+          docker run --rm
+          -v "$PWD:/repo:ro"
+          -w /repo
+          ghcr.io/gitleaks/gitleaks:v8.28.0
+          dir . --config .gitleaks.toml --redact --no-banner
+      - name: Build and scan release candidate
+        run: |
+          docker build -t cursor-sdk2api:release-scan .
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            aquasec/trivy:0.66.0 image \
+            --exit-code 1 --ignore-unfixed --severity CRITICAL \
+            cursor-sdk2api:release-scan
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: image
+        name: Normalize GHCR image name
+        shell: bash
+        run: echo "name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+      - id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ steps.image.outputs.name }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+      - id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            REVISION=${{ github.sha }}
+            SOURCE_URL=${{ github.server_url }}/${{ github.repository }}
+          provenance: mode=max
+          sbom: true
+      - name: Record immutable image digest
+        shell: bash
+        run: |
+          mkdir -p release-artifacts
+          printf '%s@%s\n' "${{ steps.image.outputs.name }}" "${{ steps.build.outputs.digest }}" \
+            > release-artifacts/image-digest.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts
+          path: release-artifacts/
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          gh release create "${GITHUB_REF_NAME}"
+          release-artifacts/image-digest.txt
+          --verify-tag
+          --generate-notes
+          --title "cursor-sdk2api ${GITHUB_REF_NAME}"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,48 @@
+name: security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "17 3 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Secret scan
+        run: >-
+          docker run --rm
+          -v "$PWD:/repo:ro"
+          -w /repo
+          ghcr.io/gitleaks/gitleaks:v8.28.0
+          dir . --config .gitleaks.toml --redact --no-banner
+      - uses: docker/setup-buildx-action@v4
+      - name: Build scan image
+        run: docker build --load -t cursor-sdk2api:security .
+      - name: Vulnerability scan
+        run: >-
+          docker run --rm
+          -v /var/run/docker.sock:/var/run/docker.sock
+          aquasec/trivy:0.66.0 image
+          --exit-code 1 --ignore-unfixed --severity CRITICAL
+          cursor-sdk2api:security
+      - name: Generate SPDX SBOM
+        run: >-
+          docker run --rm
+          -v /var/run/docker.sock:/var/run/docker.sock
+          -v "$PWD:/out"
+          anchore/syft:v1.32.0
+          cursor-sdk2api:security -o spdx-json=/out/cursor-sdk2api.spdx.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cursor-sdk2api-sbom
+          path: cursor-sdk2api.spdx.json

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,10 @@
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Synthetic canaries that verify credential redaction"
+regexes = [
+  '''^sk-canary-SECRET-123456789$''',
+  '''^sk-live-canary-ABCDEFGH$''',
+  '''^sk-receipt-canary-XYZ12345$''',
+]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,9 @@
 1. Deterministic contract tests with the injected fake SDK (`tests/contract`, `tests/integration`).
 2. Isolated Docker build.
 3. Opt-in live smoke only (`scripts/live-smoke`). Never put real credentials in fixtures or CI.
+4. `integrations/new-api/compose-e2e.sh` is credential-free infrastructure
+   evidence. `integrations/new-api/smoke.mjs` is opt-in live-model evidence and
+   requires a new-api user token plus locally configured channels.
 
 ## Rules
 
@@ -20,4 +23,24 @@ npm ci
 npm run typecheck
 npm test
 npm run build
+npm run secret:scan
 ```
+
+For integration or release changes also run:
+
+```bash
+bash integrations/new-api/compose-e2e.sh
+```
+
+## Release discipline
+
+- Never commit `.env`, rendered channel JSON, Cursor keys, new-api tokens,
+  cookies, proxy credentials, `STATE_DIR`, or SQLite state.
+- `package.json` is the release version source. A release tag must equal
+  `v<package version>`.
+- Tags and formal GitHub Releases are maintainer gates. A PR may change the
+  dormant workflow but must not create a tag or publish an image.
+- Before the next approved tag, bump `package.json`; the published `v0.1.0`
+  tag already consumes version `0.1.0`.
+- Release CI publishes multi-architecture GHCR images and attaches provenance,
+  SBOM, and an immutable digest receipt. Record the digest, not only a tag.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,31 @@
-FROM node:22.19-bookworm-slim AS build
+FROM node:22.19-bookworm-slim@sha256:4a4884e8a44826194dff92ba316264f392056cbe243dcc9fd3551e71cea02b90 AS build
 WORKDIR /app
 COPY package.json package-lock.json ./
 COPY tsconfig.json tsconfig.build.json ./
 COPY src ./src
 COPY web ./web
-RUN npm ci && npm run build
+RUN npm ci && npm run build && npm prune --omit=dev && mkdir /app/data
 
-FROM node:22.19-bookworm-slim
+FROM gcr.io/distroless/nodejs22-debian13:nonroot@sha256:939d6f1671529d230f50b563578e9b5d206af58f038b10ebd7e1233023d4e167
+ARG VERSION=dev
+ARG REVISION=unknown
+ARG SOURCE_URL=https://github.com/Sunnyender-org/cursor-sdk2api
 WORKDIR /app
 ENV NODE_ENV=production
-COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
-COPY --from=build /app/dist ./dist
-COPY LICENSE NOTICE.md README.md README.zh-CN.md ./
-RUN mkdir -p /data && chown node:node /data
+ENV GATEWAY_VERSION=${VERSION}
+LABEL org.opencontainers.image.title="cursor-sdk2api" \
+      org.opencontainers.image.description="Official Cursor SDK gateway with Anthropic and OpenAI compatible APIs" \
+      org.opencontainers.image.source="${SOURCE_URL}" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.licenses="MIT"
+COPY --from=build --chown=65532:65532 /app/node_modules ./node_modules
+COPY --from=build --chown=65532:65532 /app/dist ./dist
+COPY --from=build --chown=65532:65532 /app/data /data
+COPY --chown=65532:65532 LICENSE NOTICE.md README.md README.zh-CN.md ./
 ENV STATE_DIR=/data
-USER node
 EXPOSE 8080
 VOLUME ["/data"]
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD ["node", "-e", "fetch('http://127.0.0.1:'+(process.env.PORT||8080)+'/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
-CMD ["node", "dist/index.js"]
+  CMD ["/nodejs/bin/node", "-e", "fetch('http://127.0.0.1:'+(process.env.PORT||8080)+'/health').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+CMD ["dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Point each client at the protocol it already speaks. Mixing them on one channel 
 | **Grok Build** | custom model `api_backend = "responses"` → `POST /v1/responses` | Messages. If the client later sends `previous_response_id`, this gateway returns 422; switch that model to `chat_completions`. |
 | **Codex / OpenAI Responses** | `base_url` `…/v1`, `wire_api = "responses"` → `POST /v1/responses` | Assume OpenAI store semantics. `previous_response_id`, `store=true`, conversation objects, and hosted tools fail closed. |
 | **OpenAI SDK / generic Chat** | `base_url` `…/v1` → `POST /v1/chat/completions` | Messages unless the client is Anthropic-shaped. |
-| **new-api / one-api** | Anthropic upstream = origin (Messages); OpenAI upstream = `origin/v1` (Chat) | Mix both on one channel. There is no official new-api channel PR yet; configure a generic sidecar. |
+| **new-api / one-api** | Two generic channels, both pointed at the gateway origin: Anthropic for Messages; OpenAI for Chat / Responses | Do not embed the SDK in new-api or mix both protocols on one channel. Upstream PR #6869 was closed; use the external sidecar. |
 
 Claude Code, Grok Build, and Codex edit **your local project** with **their** tools. The gateway only runs the model. Cursor SDK `cwd` is an empty per-credential directory, so the model may emit that absolute path. Prefer relative paths, or your real project path.
 
@@ -125,6 +125,24 @@ docker run --rm -p 8080:8080 -e AUTH_MODE=byok cursor-sdk2api:local
 ```
 
 `docker-compose.yml` is a single-service wrapper. It defaults `STATE_DIR` to `/data` on a named volume and does not ship secrets.
+
+For a zero-patch new-api deployment, start the gateway and new-api on one
+network, then configure new-api's existing Anthropic and OpenAI channels:
+
+```bash
+cd integrations/new-api
+cp .env.example .env
+docker compose up -d --build
+```
+
+See [`docs/NEW_API_INTEGRATION.md`](docs/NEW_API_INTEGRATION.md) for immutable
+image pins, channel templates, BYOK/managed key placement, the clean compose
+E2E, and the text/Sonnet/Grok acceptance script.
+
+Future approved version tags run a multi-architecture GHCR workflow with
+provenance, SBOM attestations, security scans, generated release notes, and an
+immutable digest receipt. The existing v0.1.0 source Release has no GHCR asset;
+do not infer an image publication from the tag or source CI.
 
 Copy [`.env.example`](.env.example) for the full configuration surface. Never commit real keys.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -51,7 +51,7 @@
 | **Grok Build** | 自定义模型 `api_backend = "responses"` → `POST /v1/responses` | Messages。若客户端后来带上 `previous_response_id`，本网关会 422；把该模型改成 `chat_completions`。 |
 | **Codex / OpenAI Responses** | `base_url` 指到 `…/v1`，`wire_api = "responses"` → `POST /v1/responses` | 不要假定 OpenAI store 语义。`previous_response_id`、`store=true`、conversation 和托管工具会 fail closed。 |
 | **OpenAI SDK / 通用 Chat** | `base_url` 指到 `…/v1` → `POST /v1/chat/completions` | 除非客户端是 Anthropic 形态，否则不要走 Messages。 |
-| **new-api / one-api** | Anthropic 上游 = origin（Messages）；OpenAI 上游 = `origin/v1`（Chat） | 同一通道混用两种协议。目前没有官方 new-api 渠道 PR，按通用 sidecar 配置。 |
+| **new-api / one-api** | 建两个通用渠道，都指向 gateway origin：Anthropic 走 Messages；OpenAI 走 Chat / Responses | 不要把 SDK 嵌进 new-api，也不要在一个渠道里混两种协议。上游 PR #6869 已关闭，使用外置 sidecar。 |
 
 Claude Code、Grok Build、Codex 改的是**你本机项目**，用的是**它们自己的工具**。网关只跑模型。Cursor SDK 的 `cwd` 是按凭证隔离的空目录，所以模型有时会吐出那个绝对路径。优先写相对路径，或写你的真实项目路径。
 
@@ -125,6 +125,23 @@ docker run --rm -p 8080:8080 -e AUTH_MODE=byok cursor-sdk2api:local
 ```
 
 `docker-compose.yml` 是单服务包装。它把 `STATE_DIR` 默认设为命名卷上的 `/data`，并且不携带密钥。
+
+new-api 可直接使用零补丁双服务示例：先让 gateway 与 new-api 进入同一网络，
+再配置 new-api 已有的 Anthropic 与 OpenAI 渠道：
+
+```bash
+cd integrations/new-api
+cp .env.example .env
+docker compose up -d --build
+```
+
+不可变镜像 pin、渠道模板、BYOK/managed 密钥边界、干净 compose E2E，
+以及 text / Sonnet / Grok 验收脚本见
+[`docs/NEW_API_INTEGRATION.md`](docs/NEW_API_INTEGRATION.md)。
+
+未来经批准的版本 tag 会构建 amd64/arm64 GHCR 镜像，并生成 provenance、
+SBOM、安全扫描、Release notes 与不可变 digest 回执。现有 v0.1.0 源码
+Release 没有 GHCR 资产，不能从 tag 或源码 CI 推断镜像已经发布。
 
 完整配置面见 [`.env.example`](.env.example)。不要提交真实密钥。
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -28,6 +28,35 @@ docker run --rm -p 8080:8080 -e AUTH_MODE=byok cursor-sdk2api:local
 
 `docker-compose.yml` is a single-service wrapper. It does not mount files from other projects and does not ship secrets.
 
+## GHCR releases
+
+An approved `v<package-version>` tag runs the release workflow. It re-runs the
+deterministic gate, secret scan, and critical-image vulnerability scan, then
+publishes `linux/amd64` and `linux/arm64` images with OCI provenance and SBOM
+attestations. The generated GitHub Release includes `image-digest.txt` so an
+operator can deploy an immutable reference:
+
+The runtime stage is a pinned non-root distroless Node 22 / Debian 13 image. It contains no
+shell, package manager, or npm CLI; production dependencies are pruned in the
+build stage and copied into the runtime image.
+
+```bash
+docker pull ghcr.io/sunnyender-org/cursor-sdk2api@sha256:<digest>
+docker run --rm -p 8080:8080 \
+  ghcr.io/sunnyender-org/cursor-sdk2api@sha256:<digest>
+```
+
+Source changes and a green workflow do not mean an image exists. Creating the
+tag and GitHub Release remains a separate maintainer action.
+
+The existing `v0.1.0` source Release predates this GHCR workflow and has no
+container asset. Before a later approved release, bump `package.json`, create
+the matching new tag, verify the GHCR package is public, and prove an
+unauthenticated pull by digest.
+
+For a two-service new-api example, see
+[`NEW_API_INTEGRATION.md`](NEW_API_INTEGRATION.md).
+
 ## Outbound proxy
 
 The official SDK does not automatically inherit the host proxy. When

--- a/docs/NEW_API_INTEGRATION.md
+++ b/docs/NEW_API_INTEGRATION.md
@@ -1,15 +1,124 @@
 # new-api integration
 
-Phase 4 of `docs/DELIVERY_PLAN.md` adds an optional external channel to `QuantumNous/new-api`. That work is out of scope for this v0.1 slice.
+`cursor-sdk2api` is an external provider for new-api. It does not patch new-api,
+run inside the new-api process, or add the Cursor SDK to the new-api image. Both
+services use ordinary Anthropic/OpenAI-compatible HTTP on one Docker network.
 
-Until a standalone v0.1 image exists at an immutable digest:
+This guide was checked against QuantumNous/new-api main
+`e2c7aa7b102c2075eae2377df3508658d45e88dc` (2026-08-15). new-api already has
+the two required generic channel types, so no adaptor is necessary:
 
-- configure new-api / one-api / internal gateways as a generic Anthropic-compatible upstream
-- Base URL: `http://<gateway-host>:8080`
-- Key: the Cursor API key (BYOK) or the gateway access key (managed)
-- model discovery: `GET /v1/models`
-- account/health: `GET /v1/account` and `GET /health`
+| new-api channel | Type | Gateway endpoint | Recommended models |
+|---|---:|---|---|
+| Anthropic | 14 | `/v1/messages` | `claude-sonnet-4-6` |
+| OpenAI | 1 | `/v1/chat/completions`, `/v1/responses` | `grok-4.6`, `composer-2.5` |
 
-Do not embed `@cursor/sdk` or this Node process inside new-api. The gateway stays a sidecar.
+Use two channels. The Anthropic channel keeps Claude Messages and tool-result
+continuation in their native shape. The OpenAI channel keeps OpenAI function
+calls, parallel-tool fields, and Responses on their native paths.
 
-No upstream PR URL exists yet. Do not invent one.
+## Start both services
+
+```bash
+cd integrations/new-api
+cp .env.example .env
+docker compose up -d --build
+```
+
+Open `http://localhost:3000`, complete new-api's normal first-run setup, and
+create a new-api user token for client requests. The compose file does not
+create an administrator, token, or channel, and it contains no working secret.
+For a private local smoke, choose new-api's **self-use** mode; current new-api
+accepts otherwise-unpriced model IDs in that mode. In operation mode, add
+explicit model ratios/prices for `claude-sonnet-4-6`, `grok-4.6`, and
+`composer-2.5` before testing. Do not use a fallback ratio as a customer billing
+contract.
+
+For an immutable deployment, set `CURSOR_SDK2API_IMAGE` to a released digest:
+
+```dotenv
+CURSOR_SDK2API_IMAGE=ghcr.io/sunnyender-org/cursor-sdk2api@sha256:<release-digest>
+```
+
+The release workflow records the exact digest in `image-digest.txt`. A mutable
+tag is convenient for evaluation but is not an immutable production pin.
+
+## Configure channels
+
+In **Channels > Add channel**, create:
+
+1. **Anthropic**: Base URL `http://gateway:8080`, model
+   `claude-sonnet-4-6`.
+2. **OpenAI**: Base URL `http://gateway:8080`, models
+   `grok-4.6,composer-2.5`.
+
+Set the channel key according to the gateway mode:
+
+- BYOK: the channel stores a Cursor User API Key. This is simplest for a
+  single trusted operator, but the raw upstream key is then present in the
+  new-api database.
+- managed: `gateway` receives `CURSOR_API_KEY`; both new-api channels store a
+  different `GATEWAY_ACCESS_KEY`. This reduces Cursor-key copies, but both
+  environment values still need secret-store protection.
+
+The JSON files under `integrations/new-api/channel.*.template.json` document
+the current API fields. They intentionally contain a non-working placeholder;
+replace it only in a local protected copy or use the UI. Do not commit the
+rendered channel payload.
+
+new-api clients authenticate with a **new-api user token** at port 3000. They
+must never receive the Cursor key or managed gateway access key.
+
+Channel availability and billing are separate settings in new-api. Saving the
+two channels with placeholder keys proves only the schema. A user request also
+needs the model enabled for that user's group and either self-use mode or an
+explicit operator-approved model ratio/price.
+
+## Verification layers
+
+Infrastructure-only, no Cursor credential:
+
+```bash
+bash integrations/new-api/compose-e2e.sh
+```
+
+This builds a clean local gateway image, starts new-api with a fresh SQLite
+volume, proves both health endpoints, and proves new-api's Docker network can
+reach `gateway:8080`. It does not create a channel or claim a model response.
+
+After channel setup, run the credentialed acceptance matrix through new-api:
+
+```bash
+export NEW_API_BASE_URL=http://127.0.0.1:3000
+export NEW_API_TOKEN='local-new-api-user-token'
+npm run new-api:smoke
+```
+
+The script runs three repeatable cases:
+
+1. OpenAI-compatible text.
+2. Sonnet 4.6 named tool call plus `tool_result` continuation via Messages.
+3. Grok 4.6 xhigh two-tool parallel call plus both tool results.
+
+Model selection is nondeterministic upstream behavior. A run passes only when
+the exact required tool batch appears; the script does not downgrade a missed
+parallel call into success. Override `TEXT_MODEL`, `SONNET_MODEL`, or
+`GROK_MODEL` only with exact IDs returned by the gateway catalog.
+
+## Boundaries and failure semantics
+
+- Placeholder-key channel creation proves configuration shape only.
+- Deterministic tests validate request construction and ID preservation, not a
+  live Cursor model.
+- Credentialed smoke is a dated acceptance for one account, region, model
+  catalog, new-api build, and gateway image. It is not a universal guarantee.
+- Tool IDs are sufficient for pending continuation; the gateway resolves them
+  against its process-local session registry. Keep sticky instance ownership
+  and drain before replacing a live gateway.
+- Quota/account lookup may degrade to `partial` when the Dashboard control
+  plane is unavailable. Inference and usage reporting remain separate.
+- Keep `/console/` and new-api administration behind trusted-network controls.
+
+QuantumNous/new-api PR #6869 was closed by a maintainer with “无计划”. This
+repository does not reopen it, copy its embedded implementation, or claim that
+new-api officially supports a dedicated Cursor channel.

--- a/integrations/new-api/.env.example
+++ b/integrations/new-api/.env.example
@@ -1,0 +1,20 @@
+# Optional image overrides. For an immutable deployment, use name@sha256:digest.
+CURSOR_SDK2API_IMAGE=cursor-sdk2api:new-api-local
+NEW_API_IMAGE=calciumion/new-api@sha256:be4b1f3fb48687cab0e0ff921a1e4c69ae3738c0907ce05646ddc6da02cb35a5
+
+# byok starts without a server-side Cursor key. managed requires both secrets.
+CURSOR_AUTH_MODE=byok
+CURSOR_API_KEY=
+GATEWAY_ACCESS_KEY=
+
+# Generate unique values outside the repository before Internet-facing use.
+NEW_API_SESSION_SECRET=replace-with-a-random-session-secret
+NEW_API_SQLITE_PATH=/data/new-api.db
+NEW_API_PORT=3000
+
+# Used only by smoke.mjs after new-api has been initialized and channels exist.
+NEW_API_BASE_URL=http://127.0.0.1:3000
+NEW_API_TOKEN=
+TEXT_MODEL=composer-2.5
+SONNET_MODEL=claude-sonnet-4-6
+GROK_MODEL=grok-4.6

--- a/integrations/new-api/channel.anthropic.template.json
+++ b/integrations/new-api/channel.anthropic.template.json
@@ -1,0 +1,14 @@
+{
+  "mode": "single",
+  "channel": {
+    "type": 14,
+    "name": "Cursor SDK - Anthropic",
+    "key": "<CURSOR_API_KEY_OR_GATEWAY_ACCESS_KEY>",
+    "base_url": "http://gateway:8080",
+    "models": "claude-sonnet-4-6",
+    "group": "default",
+    "priority": 0,
+    "weight": 0,
+    "auto_ban": 0
+  }
+}

--- a/integrations/new-api/channel.openai.template.json
+++ b/integrations/new-api/channel.openai.template.json
@@ -1,0 +1,14 @@
+{
+  "mode": "single",
+  "channel": {
+    "type": 1,
+    "name": "Cursor SDK - OpenAI compatible",
+    "key": "<CURSOR_API_KEY_OR_GATEWAY_ACCESS_KEY>",
+    "base_url": "http://gateway:8080",
+    "models": "grok-4.6,composer-2.5",
+    "group": "default",
+    "priority": 0,
+    "weight": 0,
+    "auto_ban": 0
+  }
+}

--- a/integrations/new-api/compose-e2e.sh
+++ b/integrations/new-api/compose-e2e.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+compose_file="$script_dir/docker-compose.yml"
+NEW_API_PORT=$(node -e 'const net=require("node:net");const s=net.createServer();s.listen(0,"127.0.0.1",()=>{console.log(s.address().port);s.close()})')
+export NEW_API_PORT
+COMPOSE_PROJECT_NAME="cursor-sdk2api-e2e-${NEW_API_PORT}"
+export COMPOSE_PROJECT_NAME
+
+cleanup() {
+  docker compose -f "$compose_file" --profile verify down --volumes --remove-orphans
+}
+trap cleanup EXIT
+
+docker compose -f "$compose_file" --profile verify up -d --build gateway new-api
+docker compose -f "$compose_file" --profile verify run --rm network-probe
+curl --fail --silent --show-error "http://127.0.0.1:${NEW_API_PORT}/api/status" >/dev/null
+curl --fail --silent --show-error "http://127.0.0.1:${NEW_API_PORT}/" >/dev/null
+echo "new-api compose infrastructure E2E passed"

--- a/integrations/new-api/docker-compose.yml
+++ b/integrations/new-api/docker-compose.yml
@@ -1,0 +1,59 @@
+services:
+  gateway:
+    image: ${CURSOR_SDK2API_IMAGE:-cursor-sdk2api:new-api-local}
+    build:
+      context: ../..
+      args:
+        VERSION: compose-local
+        REVISION: local
+    pull_policy: missing
+    restart: unless-stopped
+    environment:
+      AUTH_MODE: ${CURSOR_AUTH_MODE:-byok}
+      CURSOR_API_KEY: ${CURSOR_API_KEY:-}
+      GATEWAY_ACCESS_KEY: ${GATEWAY_ACCESS_KEY:-}
+      HOST: 0.0.0.0
+      PORT: 8080
+      STATE_DIR: /data
+    volumes:
+      - gateway-data:/data
+    healthcheck:
+      test: ["CMD", "/nodejs/bin/node", "-e", "fetch('http://127.0.0.1:8080/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  new-api:
+    image: ${NEW_API_IMAGE:-calciumion/new-api@sha256:be4b1f3fb48687cab0e0ff921a1e4c69ae3738c0907ce05646ddc6da02cb35a5}
+    pull_policy: missing
+    restart: unless-stopped
+    depends_on:
+      gateway:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:${NEW_API_PORT:-3000}:3000"
+    environment:
+      TZ: Asia/Shanghai
+      SQLITE_PATH: ${NEW_API_SQLITE_PATH:-/data/new-api.db}
+      SESSION_SECRET: ${NEW_API_SESSION_SECRET:-replace-before-public-use}
+    volumes:
+      - new-api-data:/data
+
+  network-probe:
+    image: curlimages/curl@sha256:4026b29997dc7c823b51c164b71e2b51e0fd95cce4601f78202c513d97da2922
+    profiles: [verify]
+    depends_on:
+      gateway:
+        condition: service_healthy
+      new-api:
+        condition: service_started
+    command:
+      - sh
+      - -ec
+      - |
+        curl --fail --silent --show-error http://gateway:8080/health >/dev/null
+        until curl --fail --silent --show-error http://new-api:3000/api/status >/dev/null; do sleep 2; done
+
+volumes:
+  gateway-data:
+  new-api-data:

--- a/integrations/new-api/smoke.d.mts
+++ b/integrations/new-api/smoke.d.mts
@@ -1,0 +1,6 @@
+export function buildTextRequest(model: string): any;
+export function buildSonnetFirstRequest(model: string): any;
+export function buildSonnetContinuation(model: string, first: any): any;
+export function buildGrokFirstRequest(model: string): any;
+export function buildGrokContinuation(model: string, first: any): any;
+export function runSmoke(env?: NodeJS.ProcessEnv): Promise<Record<string, string>>;

--- a/integrations/new-api/smoke.mjs
+++ b/integrations/new-api/smoke.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+import process from "node:process";
+
+const tool = (name, description) => ({
+  name,
+  description,
+  input_schema: {
+    type: "object",
+    properties: { value: { type: "string" } },
+    required: ["value"],
+    additionalProperties: false,
+  },
+});
+
+export function buildTextRequest(model) {
+  return {
+    path: "/v1/chat/completions",
+    body: { model, messages: [{ role: "user", content: "Reply with exactly: new-api cursor text ok" }] },
+  };
+}
+
+export function buildSonnetFirstRequest(model) {
+  return {
+    path: "/v1/messages",
+    headers: { "anthropic-version": "2023-06-01" },
+    body: {
+      model,
+      max_tokens: 256,
+      tools: [tool("lookup_temperature", "Return the supplied temperature")],
+      tool_choice: { type: "tool", name: "lookup_temperature" },
+      messages: [{ role: "user", content: "Call lookup_temperature with value 72F, then use its result." }],
+    },
+  };
+}
+
+export function buildSonnetContinuation(model, first) {
+  const uses = first.content?.filter((block) => block.type === "tool_use") ?? [];
+  if (uses.length !== 1) throw new Error(`Sonnet expected one tool_use, received ${uses.length}`);
+  return {
+    path: "/v1/messages",
+    headers: { "anthropic-version": "2023-06-01" },
+    body: {
+      model,
+      max_tokens: 256,
+      tools: [tool("lookup_temperature", "Return the supplied temperature")],
+      messages: [
+        { role: "user", content: "Call lookup_temperature with value 72F, then use its result." },
+        { role: "assistant", content: first.content },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: uses[0].id, content: "72F" }] },
+      ],
+    },
+  };
+}
+
+const openAiTool = (name) => ({
+  type: "function",
+  function: {
+    name,
+    description: `Return ${name}`,
+    parameters: {
+      type: "object",
+      properties: { value: { type: "string" } },
+      required: ["value"],
+      additionalProperties: false,
+    },
+  },
+});
+
+export function buildGrokFirstRequest(model) {
+  return {
+    path: "/v1/chat/completions",
+    body: {
+      model,
+      reasoning_effort: "xhigh",
+      parallel_tool_calls: true,
+      tool_choice: "required",
+      tools: [openAiTool("lookup_alpha"), openAiTool("lookup_beta")],
+      messages: [{ role: "user", content: "Call both lookup_alpha(value=A) and lookup_beta(value=B) in one turn." }],
+    },
+  };
+}
+
+export function buildGrokContinuation(model, first) {
+  const message = first.choices?.[0]?.message;
+  const calls = message?.tool_calls ?? [];
+  const names = new Set(calls.map((call) => call.function?.name));
+  if (calls.length !== 2 || !names.has("lookup_alpha") || !names.has("lookup_beta")) {
+    throw new Error(`Grok expected two parallel tool calls, received ${calls.length}`);
+  }
+  return {
+    path: "/v1/chat/completions",
+    body: {
+      model,
+      reasoning_effort: "xhigh",
+      tools: [openAiTool("lookup_alpha"), openAiTool("lookup_beta")],
+      messages: [
+        { role: "user", content: "Call both lookup_alpha(value=A) and lookup_beta(value=B) in one turn." },
+        message,
+        ...calls.map((call) => ({
+          role: "tool",
+          tool_call_id: call.id,
+          content: call.function.name === "lookup_alpha" ? "alpha=A" : "beta=B",
+        })),
+      ],
+    },
+  };
+}
+
+async function request(baseUrl, token, spec) {
+  const response = await fetch(`${baseUrl}${spec.path}`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      ...spec.headers,
+    },
+    body: JSON.stringify(spec.body),
+  });
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    throw new Error(`${spec.path} returned non-JSON ${response.status}: ${text.slice(0, 300)}`);
+  }
+  if (!response.ok || body.error) {
+    throw new Error(`${spec.path} failed ${response.status}: ${JSON.stringify(body)}`);
+  }
+  return body;
+}
+
+export async function runSmoke(env = process.env) {
+  const baseUrl = (env.NEW_API_BASE_URL || "http://127.0.0.1:3000").replace(/\/$/, "");
+  const token = env.NEW_API_TOKEN;
+  if (!token) throw new Error("NEW_API_TOKEN is required; use a new-api user token, not a Cursor key");
+
+  const textModel = env.TEXT_MODEL || "composer-2.5";
+  const sonnetModel = env.SONNET_MODEL || "claude-sonnet-4-6";
+  const grokModel = env.GROK_MODEL || "grok-4.6";
+
+  const text = await request(baseUrl, token, buildTextRequest(textModel));
+  if (!text.choices?.[0]?.message?.content) throw new Error("text smoke returned no assistant content");
+
+  const sonnetFirst = await request(baseUrl, token, buildSonnetFirstRequest(sonnetModel));
+  const sonnetFinal = await request(baseUrl, token, buildSonnetContinuation(sonnetModel, sonnetFirst));
+  if (!sonnetFinal.content?.some((block) => block.type === "text" && block.text)) {
+    throw new Error("Sonnet continuation returned no final text");
+  }
+
+  const grokFirst = await request(baseUrl, token, buildGrokFirstRequest(grokModel));
+  const grokFinal = await request(baseUrl, token, buildGrokContinuation(grokModel, grokFirst));
+  if (!grokFinal.choices?.[0]?.message?.content) throw new Error("Grok continuation returned no final text");
+
+  return { text: "passed", sonnet_tool_continuation: "passed", grok_parallel_tool: "passed" };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runSmoke()
+    .then((receipt) => console.log(JSON.stringify(receipt, null, 2)))
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : error);
+      process.exitCode = 1;
+    });
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "dev": "npm run build:web && node --import tsx src/index.ts",
     "dev:web": "vite --config web/vite.config.ts",
     "lint": "npm run typecheck",
-    "live:smoke": "tsx scripts/live-smoke/run.ts"
+    "live:smoke": "tsx scripts/live-smoke/run.ts",
+    "new-api:smoke": "node integrations/new-api/smoke.mjs",
+    "secret:scan": "bash scripts/secret-scan.sh"
   },
   "dependencies": {
     "@cursor/sdk": "1.0.28",

--- a/scripts/secret-scan.sh
+++ b/scripts/secret-scan.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_dir=$(git rev-parse --show-toplevel)
+
+if command -v gitleaks >/dev/null 2>&1; then
+  exec gitleaks dir "$repo_dir" --config "$repo_dir/.gitleaks.toml" --redact --no-banner
+fi
+
+if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+  exec docker run --rm \
+    -v "$repo_dir:/repo:ro" \
+    -w /repo \
+    ghcr.io/gitleaks/gitleaks:v8.28.0 \
+    dir . --config .gitleaks.toml --redact --no-banner
+fi
+
+echo "secret scan requires gitleaks or a running Docker daemon" >&2
+exit 2

--- a/src/config.ts
+++ b/src/config.ts
@@ -100,7 +100,7 @@ export function loadConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfi
     managedCursorKey: process.env.CURSOR_API_KEY || undefined,
     gatewayAccessKey: process.env.GATEWAY_ACCESS_KEY || undefined,
     instanceId: instanceId(process.env.INSTANCE_ID),
-    version: "0.1.0",
+    version: process.env.GATEWAY_VERSION?.trim() || "0.1.0",
     sdkVersion: "1.0.28",
     globalActiveRuns: envInt("GLOBAL_ACTIVE_RUNS", 4),
     perCredentialActiveRuns: envInt("PER_CREDENTIAL_ACTIVE_RUNS", 2),

--- a/tests/integration/new-api-smoke.test.ts
+++ b/tests/integration/new-api-smoke.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildGrokContinuation,
+  buildGrokFirstRequest,
+  buildSonnetContinuation,
+  buildSonnetFirstRequest,
+  buildTextRequest,
+} from "../../integrations/new-api/smoke.mjs";
+
+describe("new-api smoke contracts", () => {
+  test("text targets the OpenAI-compatible endpoint", () => {
+    const request = buildTextRequest("model-a");
+    expect(request.path).toBe("/v1/chat/completions");
+    expect(request.body.model).toBe("model-a");
+  });
+
+  test("Sonnet continuation preserves the tool_use id", () => {
+    const first = buildSonnetFirstRequest("claude-sonnet-4-6");
+    expect(first.path).toBe("/v1/messages");
+    const continuation = buildSonnetContinuation("claude-sonnet-4-6", {
+      content: [{ type: "tool_use", id: "toolu_1", name: "lookup_temperature", input: { value: "72F" } }],
+    });
+    expect(continuation.body.messages.at(-1)?.content[0].tool_use_id).toBe("toolu_1");
+  });
+
+  test("Grok continuation requires and returns both tool ids", () => {
+    const first = buildGrokFirstRequest("grok-4.6");
+    expect(first.body.parallel_tool_calls).toBe(true);
+    const continuation = buildGrokContinuation("grok-4.6", {
+      choices: [{
+        message: {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            { id: "call_a", type: "function", function: { name: "lookup_alpha", arguments: "{\"value\":\"A\"}" } },
+            { id: "call_b", type: "function", function: { name: "lookup_beta", arguments: "{\"value\":\"B\"}" } },
+          ],
+        },
+      }],
+    });
+    expect(continuation.body.messages.slice(-2).map((message: { tool_call_id: string }) => message.tool_call_id)).toEqual(["call_a", "call_b"]);
+  });
+});


### PR DESCRIPTION
## What changed

- adds a zero-patch `integrations/new-api` deployment using new-api's existing Anthropic and OpenAI channel types
- adds channel templates plus repeatable text, Sonnet 4.6 tool-continuation, and Grok 4.6 parallel-tool smoke cases
- adds a clean credential-free compose E2E with isolated project/volumes and pinned new-api/probe images
- adds tag-gated amd64/arm64 GHCR publishing, OCI provenance/SBOM attestations, generated release notes, secret scanning, image scanning, and SBOM artifacts
- moves the runtime image to a pinned non-root distroless Node 22 / Debian 13 base
- updates English/Chinese README, deployment, integration, and contribution docs

## Why

QuantumNous/new-api already supports generic Anthropic and OpenAI-compatible upstreams. Keeping `cursor-sdk2api` external preserves the official `@cursor/sdk` as the only Cursor execution core and avoids embedding a second runtime in new-api. Upstream PR #6869 remains closed and none of its bundled implementation is copied here.

## Validation

- `npm run typecheck`
- `npm test` — 24 files / 156 tests
- `npm run build`
- `npm run secret:scan` — no leaks
- `bash integrations/new-api/compose-e2e.sh` — fresh gateway/new-api volumes, health and same-network reachability passed
- `docker buildx build --platform linux/amd64,linux/arm64 --output type=oci,... .` — passed
- Trivy 0.66.0 runtime image scan — 0 Critical
- Syft 1.32.0 SPDX JSON generation — passed
- actionlint 1.7.7 — passed
- `git diff --check` — passed

`npm audit --omit=dev` still reports the known official SDK dependency tree findings: 1 high and 2 moderate (`undici`, `@connectrpc/connect-node`, `@cursor/sdk`), with no supported upstream fix in this change.

## Explicit gates

- no real Cursor key, new-api token, cookie, proxy credential, or runtime state was used or committed
- placeholder channel templates are configuration-shape evidence only
- live text/Sonnet/Grok acceptance was not run; it remains opt-in with operator-provided credentials
- no new tag, GHCR image, GitHub Release, deployment, or QuantumNous/new-api PR was created
- the existing `v0.1.0` source Release predates this workflow and has no GHCR asset; a later release requires a version bump and explicit maintainer approval
