### PR TITLE
Validate pending tool recovery after restart

### DIFF
--- a/docs/DELIVERY_PLAN.md
+++ b/docs/DELIVERY_PLAN.md
@@ -168,12 +168,12 @@ Health returns at least:
     "parallel_tools": true,
     "replay": true,
     "agent_resume": true,
-    "pending_tool_restart_resume": false
+    "pending_tool_restart_resume": true
   }
 }
 ```
 
-Capabilities are runtime truth, not marketing constants. `pending_tool_restart_resume` remains false until kill/restart live acceptance proves exact pending callback recovery.
+Capabilities are runtime truth, not marketing constants. `pending_tool_restart_resume` is enabled because kill/restart live acceptance now proves exact pending callback recovery through persisted SDK Agent lineage. Credential, model, tool catalog, and pending tool-id mismatches still fail closed.
 
 ### 7.3 Models Contract
 
@@ -548,7 +548,7 @@ Gate:
 | Default logs contain no secrets/tool payloads | local + real-smoke | log capture, secret canary scanner and redacted receipt scan | passed-live | Three isolated receipts contained no credential, Bearer token, home path or personal identity |
 | Client disconnect cancels or retains by contract | integration | abort-before-output and abort-after-tool fixtures | passed-local | Each path deterministic |
 | Graceful shutdown drains active sessions | integration | controlled signal and active-count harness | passed-local | Includes drain continuation and capacity behavior |
-| Hard restart behavior is explicit | real-smoke | kill/restart pending tool test | passed-live | All four required models returned `cursor_session_lost`, never empty success |
+| Hard restart behavior is explicit | real-smoke | kill/restart pending tool test | passed-live | Sonnet 4.6 and Grok 4.6 resumed the persisted pending SDK Agent and returned the opaque result marker; mismatches remain fail-closed |
 | Docker image starts independently | local | Docker build/run, HEALTHCHECK and health readback | passed-local | Clean-checkout rebuild remains a release gate; no external bind mount |
 | Claude Code Fable 5 passes | real-smoke | isolated real client transcript receipt | passed-live | No raw prompts/tool results retained |
 | OpenAI Chat compatibility passes | real-smoke | v0.2 client matrix | pending | Local Chat contract suite exists; live Chat matrix is not claimed |
@@ -635,7 +635,7 @@ Debug mode is explicit opt-in, allowlisted and still redacted；README 必须警
 |---|---|---|---|
 | SDK API/version drift | build or runtime break | exact pin, types inspection, full matrix on upgrade | block upgrade release |
 | SDK all-rights-reserved/Terms change | distribution risk | dependency only, current Terms review, partner/legal confirmation | block public release if unresolved |
-| Pending callback lost on crash | broken tool continuation | drain, explicit session_lost, restart acceptance, later durable broker | no HA claim until passed |
+| Pending callback recovery drifts | broken tool continuation | persisted SDK Agent lineage, exact identity/catalog/batch checks, restart acceptance | block release if restart matrix regresses |
 | Duplicate tool result | repeated external side effect | digest idempotency and one resolve | block v0.1 |
 | Mixed credentials or tenants | privacy/correctness incident | fingerprint binding, negative tests and owner lease | block v0.1 |
 | Empty SDK terminal | false success and wrong billing | semantic output gate | block v0.1 |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -86,11 +86,11 @@ Set `STATE_DIR` for:
 
 Host / local-dev default (no `STATE_DIR`) is a process temp path: `$TMPDIR/cursor-sdk2api/state`. The container **image** and `docker-compose.yml` default `STATE_DIR` to `/data` and compose declares a named volume. A bare `docker run` without `-e STATE_DIR` still gets `/data` from the image `ENV`.
 
-Lineage stores only session id, SDK agent id, credential fingerprint, model and explicit model parameters, state, pending tool ids, optional result digest, and timestamps. It does not store API keys, prompts, or tool args/results. Assistant replay bodies are **not** persisted; in-process duplicate-same still works, but after a restart a tool-result replay is `409 cursor_session_lost`.
+Lineage stores only session id, SDK agent id, credential fingerprint, model and explicit model parameters, state, pending tool ids and names, optional result digest, and timestamps. It does not store API keys, prompts, tool args, or tool results. Pending tool results can resume the persisted SDK Agent after restart when the client resends the exact tool catalog and pending id batch. Assistant replay bodies are **not** persisted, so duplicate-same replay after a later restart is still unavailable.
 
-Session/registry TTL and the periodic sweep share the same clock. Completed lineage expires with `SESSION_TTL_MS` (default 30 minutes). Pending records stay until that TTL so a restart `tool_result` is a deterministic `cursor_session_lost`, then they are deleted. Graceful shutdown does not delete recoverable completed lineage.
+Session/registry TTL and the periodic sweep share the same clock. Completed and recoverable pending lineage expire with `SESSION_TTL_MS` (default 30 minutes), then they are deleted. Graceful shutdown does not delete recoverable lineage.
 
-Completed follow-up with `x-cursor-session-id` can `Agent.resume` within the session TTL if credential and model match. Pending tool callbacks are never restored.
+Completed follow-up with `x-cursor-session-id` can `Agent.resume` within the session TTL if credential and model match. Pending callback Promises themselves are not serialized; after restart the gateway resumes the persisted SDK Agent and injects the exact host tool-result batch after validating credential, model, catalog, and ids.
 
 ## Unified gateway key and BYOK
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -31,7 +31,7 @@ separately protected environment secret.
 - Managed requests authenticate with the gateway key, but SDK sessions bind to the selected Cursor credential fingerprint and model. Continuation cannot rotate to another account.
 - SDK stores and empty workspaces are partitioned by credential fingerprint with owner-only directories; a tenant never receives another tenant's partition path or Agent ID through the HTTP API.
 - Duplicate different tool results fail closed to avoid a second side effect.
-- After restart, pending continuations are `cursor_session_lost` rather than a silent new Agent.
+- After restart, pending continuations resume only from persisted SDK Agent lineage with an exact credential, model, tool catalog, and pending tool-id batch. Any mismatch fails closed rather than starting a silent new Agent.
 - Completed resume is bound to credential fingerprint + model. Mismatch is `409 cursor_session_conflict`.
 - Gateway lineage files are owner-only (`0700`/`0600`) and contain only resume metadata, including non-secret model parameters; they omit API keys, prompts, system text, tool schemas/args/results, and assistant replay bodies. Corrupt records are quarantined and ignored. Optional `lastResultDigest` is a hash, not a payload.
 - `STATE_DIR` is sensitive local state: lineage metadata plus the official SDK store (conversation/checkpoint payloads). Treat it as owner-only. Prefer an encrypted volume and `0700` access; do not share or backup the directory as if it were anonymous cache.

--- a/docs/evidence/2026-08-18-native-compat-live-smoke.md
+++ b/docs/evidence/2026-08-18-native-compat-live-smoke.md
@@ -1,0 +1,25 @@
+# Native compatibility live smoke — 2026-08-18
+
+This is the redacted public summary of an opt-in local live run against the official Cursor SDK. The machine receipt remains outside git and contains no prompt, tool payload, account identity, or credential.
+
+## Result
+
+- Gateway: current `main` plus the pending-restart acceptance correction
+- Models: exact catalog IDs `claude-sonnet-4-6` and `grok-4.6`
+- Grok effort: explicit `xhigh`
+- Result: `ok=true`, `incomplete=false`, `required_failures=0`
+
+| Case | Sonnet 4.6 | Grok 4.6 |
+|---|---:|---:|
+| non-stream text | pass, 9.1s | pass, 6.1s |
+| incremental SSE | pass, 7.5s | pass, 6.3s |
+| single tool continuation | pass, 14.3s | pass, 12.5s |
+| same-turn parallel tools | pass, 15.4s | pass, 20.6s |
+| multi-round tools | pass, 22.4s | pass, 16.1s |
+| duplicate-same replay | pass, 77.3s | pass, 11.9s |
+| pending tool recovery after hard restart | pass, 23.4s | pass, 19.7s |
+| completed Agent resume after restart | pass, 18.1s | pass, 16.9s |
+
+The hard-restart case opens a real tool call, terminates and restarts the gateway process, resends the original tool catalog and exact pending tool result, then requires the opaque result marker in the final model answer. A 200 response without that marker does not pass.
+
+Grok thinking was skipped because the authenticated Cursor catalog did not expose that capability for this model. It is not counted as a required failure.

--- a/tests/live-smoke/README.md
+++ b/tests/live-smoke/README.md
@@ -24,7 +24,7 @@ Child mode binds **127.0.0.1** on a free port, uses isolated temp `STATE_DIR` / 
 
 ## What it checks
 
-Per resolved catalog id: authenticated `/v1/models`, non-stream text, SSE shape, single tool continuation, parallel two-tool batch, multi-round two batches, in-process duplicate-same replay, pending `tool_result` after hard restart (`cursor_session_lost`), completed `x-cursor-session-id` resume after restart. Fable also sends a Claude Code-style Messages header/body shape.
+Per resolved catalog id: authenticated `/v1/models`, non-stream text, SSE shape, single tool continuation, parallel two-tool batch, multi-round two batches, in-process duplicate-same replay, pending `tool_result` recovery after a hard restart, and completed `x-cursor-session-id` resume after restart. Fable also sends a Claude Code-style Messages header/body shape.
 
 Catalog-missing required names are `catalog_missing` failures, not skips. Capability skips happen only when the live catalog lists parameters and omits that capability.
 

--- a/tests/live-smoke/lib.test.ts
+++ b/tests/live-smoke/lib.test.ts
@@ -178,9 +178,9 @@ test("attach-mode not_run restart is incomplete, not a pass", () => {
   const cases: SmokeCase[] = [
     { id: "catalog/authenticated", case: "catalog_auth", status: "pass", required: true },
     {
-      id: "composer-2.5/pending_restart_lost",
+      id: "composer-2.5/pending_restart_resume",
       model: "composer-2.5",
-      case: "pending_restart_lost",
+      case: "pending_restart_resume",
       status: "not_run",
       required: true,
       reason: "attach_mode_no_process_control",

--- a/tests/live-smoke/run.ts
+++ b/tests/live-smoke/run.ts
@@ -181,7 +181,7 @@ async function runModelMatrix(
   out.push(await isolate(ctx, model, "parallel_tools", () => runParallelTools(ctx, model)));
   out.push(await isolate(ctx, model, "multi_round", () => runMultiRound(ctx, model)));
   out.push(await isolate(ctx, model, "duplicate_same", () => runDuplicateSame(ctx, model)));
-  out.push(await isolate(ctx, model, "pending_restart_lost", () => runPendingRestart(ctx, model)));
+  out.push(await isolate(ctx, model, "pending_restart_resume", () => runPendingRestart(ctx, model)));
   out.push(await isolate(ctx, model, "completed_resume", () => runCompletedResume(ctx, model)));
   if (model.toLowerCase().includes("fable")) {
     out.push(await isolate(ctx, model, "claude_code_shape", () => runClaudeCodeShape(ctx, model)));
@@ -521,9 +521,9 @@ async function runDuplicateSame(ctx: RunContext, model: string): Promise<SmokeCa
 async function runPendingRestart(ctx: RunContext, model: string): Promise<SmokeCase> {
   if (!ctx.child) {
     return {
-      id: `${model}/pending_restart_lost`,
+      id: `${model}/pending_restart_resume`,
       model,
-      case: "pending_restart_lost",
+      case: "pending_restart_resume",
       status: "not_run",
       required: true,
       reason: "attach_mode_no_process_control",
@@ -542,36 +542,43 @@ async function runPendingRestart(ctx: RunContext, model: string): Promise<SmokeC
   });
   const toolId = opened.tool_uses[0]?.id;
   if (opened.status !== 200 || !toolId) {
-    return failCase(model, "pending_restart_lost", { ...opened, reason: "no_tool_use" });
+    return failCase(model, "pending_restart_resume", { ...opened, reason: "no_tool_use" });
   }
   await ctx.child.restart();
   ctx.baseUrl = ctx.child.baseUrl;
+  const marker = opaqueMarker("restart");
   const resumed = await postMessages({
     baseUrl: ctx.baseUrl,
     apiKey: ctx.apiKey,
     timeoutMs: ctx.timeoutMs,
+    marker,
     body: {
       model,
       max_tokens: 128,
-      messages: [{ role: "user", content: [{ type: "tool_result", tool_use_id: toolId, content: "after-restart" }] }],
+      tools: liveTools(),
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: toolId,
+              content: `The recovered tool result is ${marker}. Reply with exactly ${marker}.`,
+            },
+          ],
+        },
+      ],
     },
   });
-  if (resumed.status !== 409 || resumed.error_type !== "cursor_session_lost") {
-    return failCase(model, "pending_restart_lost", {
+  if (resumed.status !== 200 || resumed.error_type || !resumed.marker_hit) {
+    return failCase(model, "pending_restart_resume", {
       ...resumed,
-      reason: "expected_session_lost",
+      reason: resumed.marker_hit ? resumed.error_type : "recovered_marker_missing",
     });
   }
-  return {
-    id: `${model}/pending_restart_lost`,
-    model,
-    case: "pending_restart_lost",
-    status: "pass",
-    required: true,
-    http_status: resumed.status,
-    error_type: resumed.error_type,
+  return passCase(model, "pending_restart_resume", resumed, {
     duration_ms: opened.duration_ms + resumed.duration_ms,
-  };
+  });
 }
 
 async function runCompletedResume(ctx: RunContext, model: string): Promise<SmokeCase> {


### PR DESCRIPTION
## Summary
- update the live runner to validate persisted SDK Agent recovery instead of the retired session-lost contract
- resend the exact tool catalog and require an opaque marker in the recovered final answer
- align deployment/security/capability docs and publish the redacted Sonnet 4.6 + Grok 4.6 receipt

## Verification
- npm test (183/183)
- npm run typecheck
- npm run build
- live matrix: claude-sonnet-4-6 + grok-4.6, required_failures=0
