### PR TITLE
Release v0.2.0 with resilient Cursor recovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ MAX_AWAITING_SESSIONS=32
 SESSION_TTL_MS=1800000
 REPLAY_TTL_MS=600000
 RUN_DEADLINE_MS=3600000
-FIRST_EVENT_TIMEOUT_MS=60000
+FIRST_EVENT_TIMEOUT_MS=40000
 # Debounce from the latest SDK custom-tool callback. Real Claude callbacks can
 # arrive more than one second apart within the same assistant turn.
 TOOL_BATCH_SETTLE_MS=1500

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@
 - **Claude 1M mode:** when Cursor's live catalog exposes `context=1m`, including on Sonnet 4.6 and Fable 5, the official SDK parameter is forwarded unchanged.
 - **Native client tools:** filesystem, shell, web, and network tools stay in Claude Code, Grok, or Codex and run in your local workspace.
 - **One tool engine:** all three protocols share the same Cursor SDK run, parallel-tool, continuation, replay, and session coordinator.
-- **One gateway key, many accounts:** persistent Cursor account pool, model-aware round-robin, session-sticky continuation, Dashboard quota, web console, and Docker.
+- **One gateway key, many accounts:** persistent Cursor account pool, model-aware round-robin, stale SDK-auth recovery, pre-semantic account failover, Dashboard quota, web console, and Docker.
+- **Cold continuation recovery:** a complete client transcript can rebuild an expired or moved tool turn while replaying already-completed tools locally instead of executing their side effects twice.
 - **new-api integrated:** ready-made external deployment, channel templates, compose E2E, and acceptance smoke. [Open the new-api guide](docs/NEW_API_INTEGRATION.md).
 
 > Cursor-routed Grok does not provide xAI-native `x_search`. Client-owned web and network tools still work as normal function tools.
@@ -116,13 +117,13 @@ Client tools are converted to SDK `local.customTools` through MCP. The model cho
 - `/health`: capabilities, SDK version, and proxy transport mode
 - `STATE_DIR`: account, SDK store, and resume state
 
-Managed mode follows CPA's split between client keys and upstream credentials: clients receive only `GATEWAY_ACCESS_KEY`; imported Cursor keys stay in the gateway account store. New sessions use model-aware round-robin, while tool continuation and resume stay pinned to the original account. BYOK remains available for a trusted single-user sidecar.
+Managed mode follows CPA's split between client keys and upstream credentials: clients receive only `GATEWAY_ACCESS_KEY`; imported Cursor keys stay in the gateway account store. New sessions use model-aware round-robin. Continuations stay pinned when the original account is healthy; before semantic output, one alternate managed account may be tried. If the original account/session is gone, an exact full transcript can cold-branch safely. BYOK remains available for a trusted single-user sidecar.
 
 `v0.1` is a trusted single-process sidecar. The management account endpoint has no separate authentication. Imported Cursor keys are stored in owner-only state files and are never returned to the browser after import. The supplied compose files bind the console to loopback; authenticate and restrict `/console/` plus `/v0/management/*` at any Internet-facing proxy.
 
 ## Verification
 
-The deterministic suite contains 167 tests. The dated, redacted live receipt covers Sonnet 4.6, Fable 5, Composer 2.5, and Grok 4.6 xhigh: [live smoke evidence](docs/evidence/2026-08-15-live-smoke.md).
+The deterministic suite contains 189 tests. The latest redacted receipt proves persisted and full-transcript recovery on Sonnet 4.6 and Grok 4.6 xhigh: [recovery live smoke](docs/evidence/2026-08-19-beefapi-sync-live-smoke.md). The earlier four-model receipt also covers Fable 5 and Composer 2.5: [four-model evidence](docs/evidence/2026-08-15-live-smoke.md).
 
 ```bash
 npm run typecheck

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,7 +30,8 @@
 - **Claude 1M 模式：** Cursor 实时目录暴露 `context=1m` 时，包括 Sonnet 4.6、Fable 5，网关会把官方 SDK 参数原样转发。
 - **客户端原生工具：** 文件、shell、网页和网络工具仍由 Claude Code、Grok 或 Codex 在你的本机工作区执行。
 - **一套工具引擎：** 三种协议共用同一个 Cursor SDK Run、并行工具、续轮、replay 和 session coordinator。
-- **一把网关 Key，多账号共用：** Cursor 账号池持久化、按模型 round-robin、续轮粘性、Dashboard 额度、Web 控制台和 Docker。
+- **一把网关 Key，多账号共用：** Cursor 账号池持久化、按模型 round-robin、SDK 陈旧登录态恢复、语义输出前账号故障转移、Dashboard 额度、Web 控制台和 Docker。
+- **续轮冷恢复：** 客户端携带完整 transcript 时，可以重建过期或迁移的工具轮；已经执行过的同一工具由网关内部回放结果，不重复产生副作用。
 - **已集成 new-api：** 已提供外置部署、渠道模板、compose E2E 和验收 smoke。[直接查看 new-api 接入指南](docs/NEW_API_INTEGRATION.md)。
 
 > Cursor 通路里的 Grok 不提供 xAI 原生 `x_search`。客户端自己的网页和网络搜索仍可作为普通 function tool 使用。
@@ -116,13 +117,13 @@ env_key = "GATEWAY_ACCESS_KEY"
 - `/health`：能力、SDK 版本和代理传输状态
 - `STATE_DIR`：账号、SDK store 和 resume 状态
 
-Managed 模式沿用 CPA 的客户端 Key 与上游凭据分离方式：客户端只拿到 `GATEWAY_ACCESS_KEY`，导入的 Cursor Key 留在网关账号池。新会话按模型 round-robin，工具续轮和 resume 始终固定原账号。BYOK 仅作为可信单用户 sidecar 的兼容模式保留。
+Managed 模式沿用 CPA 的客户端 Key 与上游凭据分离方式：客户端只拿到 `GATEWAY_ACCESS_KEY`，导入的 Cursor Key 留在网关账号池。新会话按模型 round-robin；正常续轮固定原账号，尚未产生语义输出时允许一次备用账号重试。原账号或 SDK 会话丢失时，只要 transcript 完整且自洽，网关可安全冷恢复。BYOK 仅作为可信单用户 sidecar 的兼容模式保留。
 
 `v0.1` 是可信单进程 sidecar。账号管理接口没有单独认证；导入的 Cursor Key 会保存在仅 Owner 可读的状态文件中，导入后不会再返回给浏览器。随附 compose 已把控制台绑定到本机回环；任何公网反代都必须认证并限制 `/console/` 与 `/v0/management/*`。
 
 ## 验证
 
-确定性测试共 167 项。有日期、已脱敏的真实验收覆盖 Sonnet 4.6、Fable 5、Composer 2.5 和 Grok 4.6 xhigh：[live smoke 回执](docs/evidence/2026-08-15-live-smoke.md)。
+确定性测试共 189 项。最新脱敏回执证明 Sonnet 4.6 与 Grok 4.6 xhigh 的持久化恢复和完整 transcript 冷恢复：[恢复 live smoke](docs/evidence/2026-08-19-beefapi-sync-live-smoke.md)。较早的四模型回执还覆盖 Fable 5 与 Composer 2.5：[四模型回执](docs/evidence/2026-08-15-live-smoke.md)。
 
 ```bash
 npm run typecheck

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,6 +48,10 @@ SDK Agent history lives in credential-partitioned `$STATE_DIR/sdk-store/<fingerp
 
 Completed follow-up with `x-cursor-session-id` looks up lineage, checks fingerprint/model, then `Agent.resume` + `send` on that same store. Pending callback Promises are not serialized; the lineage stores only tool ids and names. After owner death, an exact credential/model/tool-id batch resumes the persisted Agent and sends a synthetic host-recovery turn with `local.force=true`. Concurrent duplicate-same recovery is singleflight. Assistant replay bodies are not persisted, so duplicate-same after a later process restart still has no persisted response body.
 
+When no exact live or persisted owner can attach, tool continuation may cold-branch only from a self-contained transcript. The latest assistant tool batch must exactly match the submitted result ids and every call must exist in the request catalog. Historical completed calls are indexed by stable tool-name/input signature; if the recovered Harness requests one again, the gateway returns the recorded result internally rather than exposing the same side effect to the client twice. Identical recovery requests are singleflight and replayable for the normal replay TTL.
+
+Before any semantic response is emitted, a generic SDK authentication-session failure is checked with an official `Cursor.me` credential probe. A still-valid key receives one same-credential Agent rebuild; an invalid key fails immediately. Managed mode may then try one different compatible account for authentication, permission, rate-limit, timeout, or upstream failures. No retry occurs after response headers/deltas begin.
+
 ## Injection
 
 Production uses `createCursorRuntime({ stateDir })` and passes the matching credential-partitioned `JsonlLocalAgentStore` and workspace to every `Agent.create` and `Agent.resume`. Tests inject `FakeSdk`. The HTTP layer never imports `@cursor/sdk` directly except through that adapter.

--- a/docs/DELIVERY_PLAN.md
+++ b/docs/DELIVERY_PLAN.md
@@ -154,7 +154,7 @@ Health returns at least:
 {
   "status": "ok",
   "service": "cursor-sdk2api",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "sdk_version": "1.0.x",
   "runtime": "local",
   "capabilities": {

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -96,7 +96,7 @@ Completed follow-up with `x-cursor-session-id` can `Agent.resume` within the ses
 
 - BYOK: clients send a Cursor API key. Suitable for a trusted local sidecar.
 - Managed pool: set `AUTH_MODE=managed` and `GATEWAY_ACCESS_KEY`, then import one or more Cursor keys in `/console/`. `CURSOR_API_KEY` is optional and only seeds the persistent pool.
-- New sessions use model-aware round-robin across compatible accounts. Tool continuation, completed follow-up, and restart recovery stay bound to the original credential fingerprint.
+- New sessions use model-aware round-robin across compatible accounts. Tool continuation, completed follow-up, and exact persisted restart recovery stay bound to the original credential fingerprint. Before semantic output, managed mode may try one alternate compatible account. If the original account is removed, a self-contained tool transcript may cold-branch to another compatible account.
 
 BYOK credentials share the gateway process and capacity limits, but their official SDK stores and empty workspace directories are separated by credential fingerprint. This is process-local tenant isolation, not a claim of hardened hostile multi-tenant hosting; public Internet deployment still requires TLS, access controls, encrypted state, monitoring, and an explicit operator threat model.
 
@@ -109,10 +109,10 @@ In-process SDK Run handles and pending tool Promises cannot move to another proc
 3. Wait until active sessions reach zero or the drain deadline.
 4. Then replace the process. Completed lineage under `STATE_DIR` survives; pending tool turns do not.
 
-A load balancer that retries a pending continuation onto a new replica will see `409 cursor_session_lost`. That is the correct failure, not a successful empty turn.
+A replica without the original live handle first tries persisted lineage. If that is unavailable, it may cold-branch only from a complete transcript with an exact latest tool batch; otherwise it returns `409 cursor_session_lost` rather than an empty success.
 
 Completed follow-up after restart requires the same `STATE_DIR` volume, `x-cursor-session-id`, and the original account still present in the pool.
 
 ## Resource defaults
 
-Development defaults: 4 global active runs, 2 per credential, 30 minute awaiting TTL, 10 minute replay TTL, 60 minute run deadline.
+Development defaults: 4 global active runs, 2 per credential, 30 minute awaiting TTL, 10 minute replay TTL, 60 minute run deadline, and 40 seconds to the first SDK event.

--- a/docs/PROTOCOL_COMPATIBILITY.md
+++ b/docs/PROTOCOL_COMPATIBILITY.md
@@ -26,6 +26,7 @@ Outer agents (Claude Code, Grok Build) execute their own local file tools in the
 | usage / cache | pass-through | Final-only cumulative; omit missing fields |
 | completed `x-cursor-session-id` follow-up | yes | Store + `Agent.resume` within TTL |
 | pending tool restart | yes | Exact credential/model/tool batch resumes with persisted SDK Agent lineage and `local.force=true` |
+| expired/moved tool continuation | yes | A complete transcript whose latest assistant tool batch exactly matches the submitted results can cold-branch to a new SDK Agent; recorded identical tools replay internally |
 | duplicate-same after restart | no | Digest only; no persisted assistant replay |
 | `/v1/models` | yes | BYOK returns one account catalog. Managed mode returns the union of exact catalog ids across the pool. |
 | `/v1/account` | yes | BYOK returns one account. Managed mode returns every pooled identity and real Cursor Dashboard period usage without exposing raw keys. |
@@ -54,11 +55,14 @@ The gateway does not implement OpenAI `previous_response_id` reconstruction, `st
 | Pending tool turn | Latest `input` items must be only `function_call_output`. Each `call_id` is the live `tool_use_id`. | `previous_response_id`, response `id`, output item `id` |
 | Same outputs again | Request/result digest replay. No second `resolve`. | A new Agent/Run |
 | Completed follow-up | `x-cursor-session-id` on a new `input` that is not a tool-output suffix, same credential/model/params | `previous_response_id` |
-| After process restart, still awaiting tools | Resume the persisted SDK Agent with the exact credential/model/tool-id batch and `local.force=true` | Missing catalog, mismatched identity, or a different result batch |
+| After process restart, still awaiting tools | Resume the persisted SDK Agent with the exact credential/model/tool-id batch and `local.force=true` | Missing catalog or an incomplete result batch |
+| SDK session/account no longer attachable | Cold-branch from the complete transcript and replay completed tool signatures internally | Missing assistant calls, missing catalog, or results that do not exactly match the latest tool batch |
 
 `function_call_output` mixed with a later user/message item is `422`. Missing required `call_id`s, unknown ids, and mixed-session ids fail closed the same way as Messages `tool_result`.
 
 Live catalog/text/tool/restart matrix is an opt-in runner (`npm run live:smoke`), not default CI. Catalog-missing required model names fail closed; they are not green skips. This file does not record live model results.
+
+Runtime discovery exposes `transcript_tool_recovery`, `stale_auth_recovery`, and `managed_account_failover` in `/health`. The last capability applies only to managed mode and only before an HTTP response has begun.
 
 ## Error types
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -31,7 +31,8 @@ separately protected environment secret.
 - Managed requests authenticate with the gateway key, but SDK sessions bind to the selected Cursor credential fingerprint and model. Continuation cannot rotate to another account.
 - SDK stores and empty workspaces are partitioned by credential fingerprint with owner-only directories; a tenant never receives another tenant's partition path or Agent ID through the HTTP API.
 - Duplicate different tool results fail closed to avoid a second side effect.
-- After restart, pending continuations resume only from persisted SDK Agent lineage with an exact credential, model, tool catalog, and pending tool-id batch. Any mismatch fails closed rather than starting a silent new Agent.
+- After restart, pending continuations prefer persisted SDK Agent lineage with an exact credential, model, tool catalog, and pending tool-id batch. A cold branch is allowed only when the client supplies a complete transcript whose latest assistant tool batch exactly matches the submitted results; otherwise it fails closed.
+- Cold recovery never blindly re-executes a completed external tool. Historical results are replayed only for the same stable tool-name/input signature, in transcript order; genuinely new calls still return to the client.
 - Completed resume is bound to credential fingerprint + model. Mismatch is `409 cursor_session_conflict`.
 - Gateway lineage files are owner-only (`0700`/`0600`) and contain only resume metadata, including non-secret model parameters; they omit API keys, prompts, system text, tool schemas/args/results, and assistant replay bodies. Corrupt records are quarantined and ignored. Optional `lastResultDigest` is a hash, not a payload.
 - `STATE_DIR` is sensitive local state: lineage metadata plus the official SDK store (conversation/checkpoint payloads). Treat it as owner-only. Prefer an encrypted volume and `0700` access; do not share or backup the directory as if it were anonymous cache.

--- a/docs/evidence/2026-08-19-beefapi-sync-live-smoke.md
+++ b/docs/evidence/2026-08-19-beefapi-sync-live-smoke.md
@@ -1,0 +1,26 @@
+# Cursor recovery sync live smoke — 2026-08-19
+
+Redacted public summary of an opt-in local run against the official Cursor SDK. The private machine receipt stays outside git and contains no credential, account identity, prompt, tool payload, or workspace path.
+
+## Result
+
+- Models: exact Cursor catalog IDs `claude-sonnet-4-6` and `grok-4.6`
+- Grok effort: explicit `xhigh`
+- Result: `ok=true`, `incomplete=false`, `required_failures=0`
+- Deterministic suite: 189/189
+
+| Case | Sonnet 4.6 | Grok 4.6 xhigh |
+|---|---:|---:|
+| non-stream text | pass, 8.3s | pass, 5.7s |
+| incremental SSE | pass, 5.6s | pass, 5.9s |
+| single tool continuation | pass, 15.8s | pass, 11.5s |
+| same-turn parallel tools | pass, 16.2s | pass, 24.8s |
+| multi-round tools | pass, 20.1s | pass, 20.2s |
+| duplicate-same replay | pass, 13.7s | pass, 15.0s |
+| persisted pending recovery after restart | pass, 23.0s | pass, 20.8s |
+| full-transcript cold recovery without lineage | pass, 23.0s | pass, 22.0s |
+| completed Agent resume after restart | pass, 19.4s | pass, 19.6s |
+
+The cold-recovery case opens a real external tool turn, stops the gateway, deletes only the runner-owned lineage directory, restarts the process, and resubmits a complete transcript. The final answer must contain a new opaque result marker. Empty HTTP 200, a repeated client-facing tool call, or a missing marker fails the case.
+
+Managed multi-account pre-semantic failover and stale-auth credential probing use deterministic integration tests because the live runner intentionally uses BYOK and cannot safely force a real account outage.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cursor-sdk2api",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cursor-sdk2api",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@cursor/sdk": "1.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor-sdk2api",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Independent MIT gateway that exposes official @cursor/sdk as Anthropic- and OpenAI-compatible HTTP APIs.",
   "license": "MIT",
   "type": "module",

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,6 +50,9 @@ export interface RuntimeCapabilities {
   replay: boolean;
   agent_resume: boolean;
   pending_tool_restart_resume: boolean;
+  transcript_tool_recovery?: boolean;
+  stale_auth_recovery?: boolean;
+  managed_account_failover?: boolean;
   streaming_impl?: "sdk_onDelta";
   store_backend?: "jsonl";
 }
@@ -67,6 +70,9 @@ export const DEFAULT_CAPABILITIES: RuntimeCapabilities = {
   replay: true,
   agent_resume: true,
   pending_tool_restart_resume: true,
+  transcript_tool_recovery: true,
+  stale_auth_recovery: true,
+  managed_account_failover: true,
   streaming_impl: "sdk_onDelta",
   store_backend: "jsonl",
 };
@@ -108,7 +114,7 @@ export function loadConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfi
     sessionTtlMs,
     replayTtlMs: envInt("REPLAY_TTL_MS", 10 * 60_000),
     runDeadlineMs: envInt("RUN_DEADLINE_MS", 60 * 60_000),
-    firstEventTimeoutMs: envInt("FIRST_EVENT_TIMEOUT_MS", 60_000),
+    firstEventTimeoutMs: envInt("FIRST_EVENT_TIMEOUT_MS", 40_000),
     toolBatchSettleMs: envInt("TOOL_BATCH_SETTLE_MS", 1_500),
     catalogCacheMs: envInt("CATALOG_CACHE_MS", 5 * 60_000),
     sweepIntervalMs: envInt("SWEEP_INTERVAL_MS", 5_000),

--- a/src/core/run-coordinator.ts
+++ b/src/core/run-coordinator.ts
@@ -4,6 +4,7 @@ import type { GatewayConfig } from "../config.js";
 import type { AuthContext } from "../auth/credentials.js";
 import { digestJson } from "../digest.js";
 import {
+  GatewayError,
   invalidRequest,
   sdkFailure,
   sessionConflict,
@@ -18,6 +19,7 @@ import { EventPump, type PumpBoundary } from "./event-pump.js";
 import { Session } from "./session.js";
 import { SessionRegistry } from "./session-registry.js";
 import { batchDigest, mapClientTools } from "./tool-bridge.js";
+import { buildTranscriptRecovery } from "./transcript-recovery.js";
 import type { LineageRecord, LineageStore } from "./lineage-store.js";
 import type { TurnWriter, TurnWriterFactory } from "./turn-writer.js";
 
@@ -76,6 +78,10 @@ export class RunCoordinator {
   private readonly pendingRecoveries = new Map<
     string,
     { digest: string; promise: Promise<{ session: Session; pump: EventPump }> }
+  >();
+  private readonly transcriptRecoveries = new Map<
+    string,
+    { expiresAt: number; promise: Promise<{ session: Session; pump: EventPump }> }
   >();
 
   constructor(private readonly deps: CoordinatorDeps) {}
@@ -233,31 +239,58 @@ export class RunCoordinator {
     }
 
     const lookup = this.deps.registry.lookupByToolIds(ids);
+    let routingError: GatewayError | undefined;
     if (lookup.mixed) {
-      throw sessionConflict("tool_use_id values belong to different sessions");
+      routingError = sessionConflict("tool_use_id values belong to different sessions");
+    } else if (lookup.session && lookup.missing.length > 0) {
+      routingError = invalidRequest(`unknown tool_use_id: ${lookup.missing.join(",")}`);
     }
-    if (!lookup.session) {
-      const recorded = this.deps.lineage?.findByToolIds(ids);
-      if (recorded) {
-        await this.resumePendingLineage(
-          req,
-          res,
-          auth,
-          parsed,
-          results,
-          recorded,
-          requestId,
-          writerFactory,
-        );
+    if (!lookup.mixed && lookup.session && lookup.missing.length === 0) {
+      try {
+        await this.continueLiveSession(req, res, auth, parsed, results, lookup.session, requestId, writerFactory);
         return;
+      } catch (error) {
+        if (!isTranscriptRecoverableRoutingError(error)) throw error;
+        routingError = error;
       }
     }
-    const session = this.deps.registry.requireLive(lookup.session, ids);
-    this.assertIdentity(session, auth, parsed.model, parsed.modelParams);
-
-    if (lookup.missing.length > 0) {
-      throw invalidRequest(`unknown tool_use_id: ${lookup.missing.join(",")}`);
+    if (!lookup.mixed && !lookup.session) {
+      const recorded = this.deps.lineage?.findByToolIds(ids);
+      if (recorded) {
+        try {
+          await this.resumePendingLineage(
+            req,
+            res,
+            auth,
+            parsed,
+            results,
+            recorded,
+            requestId,
+            writerFactory,
+          );
+          return;
+        } catch (error) {
+          if (!isTranscriptRecoverableRoutingError(error)) throw error;
+          routingError = error;
+        }
+      }
     }
+    await this.recoverFromTranscript(req, res, auth, parsed, results, requestId, writerFactory, routingError);
+  }
+
+  private async continueLiveSession(
+    req: IncomingMessage,
+    res: ServerResponse,
+    auth: AuthContext,
+    parsed: ParsedMessages,
+    results: ParsedToolResult[],
+    session: Session,
+    requestId: string,
+    writerFactory: TurnWriterFactory,
+  ): Promise<void> {
+    const ids = results.map((result) => result.toolUseId);
+    this.deps.registry.requireLive(session, ids);
+    this.assertIdentity(session, auth, parsed.model, parsed.modelParams);
 
     const digest = batchDigest(results);
     if (session.lastResultDigest && session.lastResultDigest !== digest) {
@@ -307,6 +340,102 @@ export class RunCoordinator {
       );
     }
     await drive;
+  }
+
+  private async recoverFromTranscript(
+    req: IncomingMessage,
+    res: ServerResponse,
+    auth: AuthContext,
+    parsed: ParsedMessages,
+    results: ParsedToolResult[],
+    requestId: string,
+    writerFactory: TurnWriterFactory,
+    routingError?: GatewayError,
+  ): Promise<void> {
+    let recovery: ReturnType<typeof buildTranscriptRecovery>;
+    try {
+      recovery = buildTranscriptRecovery(parsed, results);
+    } catch (error) {
+      if (routingError) throw routingError;
+      throw error;
+    }
+    const now = this.deps.clock.now();
+    for (const [key, entry] of this.transcriptRecoveries) {
+      if (now >= entry.expiresAt) this.transcriptRecoveries.delete(key);
+    }
+    const key = `${auth.fingerprint}:${recovery.digest}`;
+    let entry = this.transcriptRecoveries.get(key);
+    if (!entry) {
+      const promise = this.openTranscriptRecovery(auth, parsed, results, recovery);
+      entry = {
+        expiresAt: now + this.deps.config.replayTtlMs,
+        promise,
+      };
+      this.transcriptRecoveries.set(key, entry);
+      void promise.catch(() => {
+        if (this.transcriptRecoveries.get(key)?.promise === promise) {
+          this.transcriptRecoveries.delete(key);
+        }
+      });
+    }
+    const { session, pump } = await entry.promise;
+    await this.drive(req, res, session, pump, parsed.stream, requestId, writerFactory);
+  }
+
+  private async openTranscriptRecovery(
+    auth: AuthContext,
+    parsed: ParsedMessages,
+    results: ParsedToolResult[],
+    recovery: ReturnType<typeof buildTranscriptRecovery>,
+  ): Promise<{ session: Session; pump: EventPump }> {
+    const session = this.deps.registry.create({
+      credentialFingerprint: auth.fingerprint,
+      modelId: parsed.model,
+      modelParams: parsed.modelParams,
+    });
+    session.lastResultDigest = batchDigest(results);
+    const customTools = mapClientTools(
+      parsed.tools,
+      session,
+      this.deps.clock,
+      () => undefined,
+      recovery.completedResults,
+    );
+    const deltas = createDeltaBridge();
+    try {
+      const agent = await this.deps.sdk.createAgent({
+        apiKey: auth.cursorApiKey,
+        modelId: parsed.model,
+        modelParams: session.modelParams,
+        workspaceDir: this.deps.workspaceDir,
+        clientToolNames: parsed.tools.map((tool) => tool.name),
+        customTools,
+      });
+      session.agent = agent;
+      session.sdkAgentId = agent.agentId;
+      session.state = "running";
+      const run = await agent.send({
+        text: recovery.prompt,
+        images: parsed.images,
+        customTools,
+        onDelta: deltas.ingest,
+      });
+      session.run = run;
+      const pump = new EventPump(
+        session,
+        run,
+        this.deps.clock,
+        this.deps.config.toolBatchSettleMs,
+        this.deps.config.firstEventTimeoutMs,
+      );
+      session.pump = pump;
+      deltas.attach(pump);
+      pump.ingestEarly(session.earlyCalls.splice(0));
+      return { session, pump };
+    } catch (error) {
+      this.deps.registry.forget(session, "transcript_recovery_failed");
+      throw sdkFailure(error);
+    }
   }
 
   private async resumePendingLineage(
@@ -599,7 +728,8 @@ export class RunCoordinator {
       expiresAt: session.lastActivityAt + ttl,
     };
     // Digest only — never persist assistant/tool payloads. In-process
-    // duplicate-same still replays from memory; after restart it is session_lost.
+    // duplicate-same still replays from memory. A later self-contained retry
+    // uses transcript recovery instead of a persisted assistant response body.
     if (session.lastResultDigest) record.lastResultDigest = session.lastResultDigest;
     try {
       this.deps.lineage.put(record);
@@ -701,4 +831,12 @@ function recoveredToolResultPrompt(record: LineageRecord, results: ParsedToolRes
     "Do not repeat the completed tool calls. You may call other tools only if the task still requires them.",
     ...lines,
   ].join("\n");
+}
+
+function isTranscriptRecoverableRoutingError(error: unknown): error is GatewayError {
+  return error instanceof GatewayError && (
+    error.code === "cursor_session_lost" ||
+    error.code === "cursor_session_conflict" ||
+    error.code === "invalid_request"
+  );
 }

--- a/src/core/session-registry.ts
+++ b/src/core/session-registry.ts
@@ -116,8 +116,8 @@ export class SessionRegistry {
 
   forget(session: Session, reason: string): void {
     // In-memory only. Completed lineage files stay until their own TTL so a
-    // later process can Agent.resume. Pending records also stay until TTL so
-    // a restart tool_result is deterministically session_lost.
+    // later process can Agent.resume. Pending records also stay until TTL for
+    // exact persisted recovery; a complete transcript may cold-branch later.
     const expireAt = this.clock.now() + this.limits.replayTtlMs;
     for (const [id, ownerSessionId] of this.toolIndex) {
       if (ownerSessionId !== session.sessionId) continue;

--- a/src/core/tool-bridge.ts
+++ b/src/core/tool-bridge.ts
@@ -1,6 +1,6 @@
 import { digestJson } from "../digest.js";
 import type { Clock } from "../clock.js";
-import type { SdkCustomTool } from "../sdk/port.js";
+import type { SdkCustomTool, SdkCustomToolResult } from "../sdk/port.js";
 import type { AnthropicTool } from "../protocols/anthropic/types.js";
 import type { Session } from "./session.js";
 
@@ -9,6 +9,7 @@ export function mapClientTools(
   session: Session,
   clock: Clock,
   onExecute: (session: Session) => void,
+  completedResults?: Map<string, SdkCustomToolResult[]>,
 ): Record<string, SdkCustomTool> {
   const mapped: Record<string, SdkCustomTool> = {};
   for (const tool of tools) {
@@ -16,6 +17,9 @@ export function mapClientTools(
       description: tool.description,
       inputSchema: tool.input_schema,
       async execute(args, context) {
+        const completed = completedResults?.get(completedToolSignature(tool.name, args));
+        const replay = completed?.shift();
+        if (replay !== undefined) return replay;
         const call = session.createPending(
           tool.name,
           args,
@@ -32,6 +36,10 @@ export function mapClientTools(
     };
   }
   return mapped;
+}
+
+export function completedToolSignature(name: string, input: unknown): string {
+  return digestJson({ name, input: input ?? {} });
 }
 
 export function resultDigest(toolUseId: string, content: string, isError: boolean): string {

--- a/src/core/transcript-recovery.ts
+++ b/src/core/transcript-recovery.ts
@@ -1,0 +1,118 @@
+import { digestJson } from "../digest.js";
+import { sessionLost } from "../errors.js";
+import { asBlocks, renderPrompt, stringifyToolResult } from "../protocols/anthropic/parse.js";
+import type { ParsedMessages, ParsedToolResult } from "../protocols/anthropic/types.js";
+import type { SdkCustomToolResult } from "../sdk/port.js";
+import { completedToolSignature } from "./tool-bridge.js";
+
+interface TranscriptCall {
+  name: string;
+  input: unknown;
+}
+
+export interface TranscriptRecovery {
+  digest: string;
+  prompt: string;
+  completedResults: Map<string, SdkCustomToolResult[]>;
+}
+
+export function buildTranscriptRecovery(
+  parsed: ParsedMessages,
+  currentResults: ParsedToolResult[],
+): TranscriptRecovery {
+  if (parsed.tools.length === 0) {
+    throw sessionLost("Expired tool continuation cannot recover without its tool catalog");
+  }
+  const catalog = new Set(parsed.tools.map((tool) => tool.name));
+  const calls = new Map<string, TranscriptCall>();
+  for (const message of parsed.messages) {
+    if (message.role !== "assistant") continue;
+    for (const block of asBlocks(message.content)) {
+      if (block.type !== "tool_use") continue;
+      if (calls.has(block.id)) {
+        throw sessionLost(`Tool transcript contains duplicate tool_use id: ${block.id}`);
+      }
+      calls.set(block.id, { name: block.name, input: block.input ?? {} });
+    }
+  }
+
+  const currentIds = new Set<string>();
+  for (const result of currentResults) {
+    if (currentIds.has(result.toolUseId)) {
+      throw sessionLost(`Tool transcript contains duplicate current result: ${result.toolUseId}`);
+    }
+    currentIds.add(result.toolUseId);
+    const call = calls.get(result.toolUseId);
+    if (!call || !catalog.has(call.name)) {
+      throw sessionLost(`Tool transcript is missing a catalogued call for: ${result.toolUseId}`);
+    }
+  }
+  const latestAssistantBatch = [...parsed.messages]
+    .reverse()
+    .find((message) =>
+      message.role === "assistant" && asBlocks(message.content).some((block) => block.type === "tool_use"));
+  const latestBatchIds = latestAssistantBatch
+    ? asBlocks(latestAssistantBatch.content)
+        .filter((block): block is Extract<typeof block, { type: "tool_use" }> => block.type === "tool_use")
+        .map((block) => block.id)
+        .sort()
+    : [];
+  const providedIds = [...currentIds].sort();
+  if (
+    latestBatchIds.length !== providedIds.length ||
+    latestBatchIds.some((id, index) => id !== providedIds[index])
+  ) {
+    throw sessionLost("Tool transcript results do not exactly match the latest assistant tool batch");
+  }
+
+  const completedResults = new Map<string, SdkCustomToolResult[]>();
+  const completedIds = new Set<string>();
+  for (const message of parsed.messages) {
+    if (message.role !== "user") continue;
+    for (const block of asBlocks(message.content)) {
+      if (block.type !== "tool_result") continue;
+      const call = calls.get(block.tool_use_id);
+      if (!call || !catalog.has(call.name)) continue;
+      const signature = completedToolSignature(call.name, call.input);
+      const queue = completedResults.get(signature) ?? [];
+      queue.push(
+        block.is_error === true
+          ? { content: [{ type: "text", text: stringifyToolResult(block.content) }], isError: true }
+          : stringifyToolResult(block.content),
+      );
+      completedResults.set(signature, queue);
+      completedIds.add(block.tool_use_id);
+    }
+  }
+  for (const result of currentResults) {
+    if (!completedIds.has(result.toolUseId)) {
+      throw sessionLost(`Tool transcript is incomplete for: ${result.toolUseId}`);
+    }
+  }
+
+  const rendered = renderPrompt(parsed, { includeContinuation: true });
+  const lines = currentResults.map((result) => {
+    const call = calls.get(result.toolUseId) as TranscriptCall;
+    return `TOOL_RESULT tool_use_id=${result.toolUseId} tool=${call.name} is_error=${result.isError} content=${JSON.stringify(result.content)}`;
+  });
+  const prompt = [
+    rendered.text,
+    "HOST_SESSION_RECOVERY:",
+    "The original Cursor SDK run is no longer attachable, but the complete conversation and exact external tool results are present above.",
+    "Continue the same task. Treat every completed tool call as already executed exactly once and do not repeat its external side effect.",
+    "If you request an identical completed call, the host will replay its recorded result. Call only genuinely new tools if the task still requires them.",
+    ...lines,
+  ].join("\n\n");
+
+  return {
+    digest: digestJson({
+      model: parsed.model,
+      modelParams: parsed.modelParams,
+      messages: parsed.messages,
+      tools: parsed.tools,
+      results: currentResults,
+    }),
+    prompt,
+    completedResults,
+  };
+}

--- a/src/protocols/anthropic/parse.ts
+++ b/src/protocols/anthropic/parse.ts
@@ -288,7 +288,10 @@ export function stringifyToolResult(content: unknown): string {
   }
 }
 
-export function renderPrompt(parsed: ParsedMessages): { text: string; images: Array<{ data: string; mimeType: string }> } {
+export function renderPrompt(
+  parsed: ParsedMessages,
+  options: { includeContinuation?: boolean } = {},
+): { text: string; images: Array<{ data: string; mimeType: string }> } {
   const parts: string[] = [];
   if (parsed.tools.length > 0) {
     parts.push(
@@ -301,7 +304,9 @@ export function renderPrompt(parsed: ParsedMessages): { text: string; images: Ar
     );
   }
   if (parsed.systemText) parts.push(`System:\n${parsed.systemText}`);
-  const messages = parsed.continuation ? parsed.messages.slice(0, -1) : parsed.messages;
+  const messages = parsed.continuation && !options.includeContinuation
+    ? parsed.messages.slice(0, -1)
+    : parsed.messages;
   for (const message of messages) {
     const text = asBlocks(message.content)
       .map((block) => {

--- a/src/sdk/cursor-runtime.ts
+++ b/src/sdk/cursor-runtime.ts
@@ -342,6 +342,15 @@ export function createCursorRuntime(options: { stateDir: string }): SdkRuntime {
         };
       }
     },
+    async probeCredential(apiKey: string): Promise<"valid" | "invalid" | "unavailable"> {
+      try {
+        await Cursor.me({ apiKey });
+        return "valid";
+      } catch (error) {
+        const mapped = sdkFailure(error);
+        return mapped.code === "authentication_error" ? "invalid" : "unavailable";
+      }
+    },
   };
 }
 

--- a/src/sdk/port.ts
+++ b/src/sdk/port.ts
@@ -152,6 +152,7 @@ export interface SdkRuntime {
   resumeAgent(input: ResumeAgentInput): Promise<SdkAgent>;
   listModels(apiKey: string): Promise<SdkCatalogResult>;
   getAccount(apiKey: string): Promise<SdkAccountResult>;
+  probeCredential(apiKey: string): Promise<"valid" | "invalid" | "unavailable">;
 }
 
 export function apiProfileToolAllowlist(clientToolNames: string[]): string[] {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -91,6 +91,29 @@ async function listManagedModels(accounts: StoredCursorAccount[], catalog: Model
   };
 }
 
+function managedPreSemanticFailureCanFailover(error: unknown): boolean {
+  if (!(error instanceof GatewayError)) return true;
+  if (
+    error.code === "authentication_error" ||
+    error.code === "forbidden" ||
+    error.code === "rate_limited" ||
+    error.code === "cursor_timeout" ||
+    error.code === "cursor_upstream_error"
+  ) {
+    return true;
+  }
+  return error.httpStatus >= 500;
+}
+
+function responseStarted(res: ServerResponse): boolean {
+  return res.headersSent || res.writableEnded || res.destroyed;
+}
+
+function staleCredentialSessionError(error: unknown): boolean {
+  if (!(error instanceof GatewayError) || error.code !== "authentication_error") return false;
+  return !/invalid|revoked|expired|disabled|unauthorized api key/i.test(error.message);
+}
+
 export function createApp(input: {
   config: GatewayConfig;
   sdk: SdkRuntime;
@@ -140,12 +163,18 @@ export function createApp(input: {
   const resolveManagedAuth = async (
     parsed?: ParsedMessages,
     sessionHint?: string,
+    excludedFingerprints: ReadonlySet<string> = new Set(),
   ): Promise<AuthContext> => {
     const boundFingerprint = parsed ? boundCredentialFingerprint(parsed, sessionHint) : undefined;
-    if (boundFingerprint) {
+    if (boundFingerprint && !excludedFingerprints.has(boundFingerprint)) {
       const bound = accounts.findByFingerprint(boundFingerprint);
-      if (!bound) throw sessionLost("The Cursor account bound to this session is no longer configured");
-      return managedAccountAuth(bound.apiKey);
+      if (bound) return managedAccountAuth(bound.apiKey);
+      // A self-contained tool continuation can cold-branch from its full
+      // transcript when the originally bound managed account was removed.
+      // Completed session follow-ups still require their original account.
+      if (!parsed?.continuation) {
+        throw sessionLost("The Cursor account bound to this session is no longer configured");
+      }
     }
 
     const configured = accounts.list();
@@ -173,6 +202,7 @@ export function createApp(input: {
 
     candidates = candidates.filter(
       (account) =>
+        !excludedFingerprints.has(managedAccountAuth(account.apiKey).fingerprint) &&
         registry.activeRunCountForCredential(managedAccountAuth(account.apiKey).fingerprint) <
         config.perCredentialActiveRuns,
     );
@@ -193,7 +223,70 @@ export function createApp(input: {
     client: ClientAuthorization,
     parsed?: ParsedMessages,
     sessionHint?: string,
-  ): Promise<AuthContext> => client.mode === "byok" ? client.auth : resolveManagedAuth(parsed, sessionHint);
+    excludedFingerprints: ReadonlySet<string> = new Set(),
+  ): Promise<AuthContext> => client.mode === "byok"
+    ? client.auth
+    : resolveManagedAuth(parsed, sessionHint, excludedFingerprints);
+  const credentialProbes = new Map<string, Promise<"valid" | "invalid" | "unavailable">>();
+  const probeCredential = (auth: AuthContext): Promise<"valid" | "invalid" | "unavailable"> => {
+    const existing = credentialProbes.get(auth.fingerprint);
+    if (existing) return existing;
+    const probe = sdk.probeCredential(auth.cursorApiKey);
+    credentialProbes.set(auth.fingerprint, probe);
+    void probe.finally(() => {
+      if (credentialProbes.get(auth.fingerprint) === probe) credentialProbes.delete(auth.fingerprint);
+    }).catch(() => undefined);
+    return probe;
+  };
+
+  const runWithProviderRecovery = async (
+    res: ServerResponse,
+    client: ClientAuthorization,
+    parsed: ParsedMessages,
+    sessionHint: string | undefined,
+    run: (auth: AuthContext) => Promise<void>,
+  ): Promise<void> => {
+    const first = await resolveAuth(client, parsed, sessionHint);
+    try {
+      await run(first);
+      return;
+    } catch (initialError) {
+      let error = initialError;
+      if (!responseStarted(res) && staleCredentialSessionError(error)) {
+        const probe = await probeCredential(first);
+        if (probe === "valid") {
+          logger.warn(
+            { model: parsed.model, error_type: "authentication_error" },
+            "retrying pre-semantic Cursor request after credential probe",
+          );
+          try {
+            await run(first);
+            return;
+          } catch (retryError) {
+            error = retryError;
+          }
+        }
+      }
+      if (
+        client.mode !== "managed" ||
+        responseStarted(res) ||
+        !managedPreSemanticFailureCanFailover(error)
+      ) {
+        throw error;
+      }
+      let alternate: AuthContext;
+      try {
+        alternate = await resolveAuth(client, parsed, sessionHint, new Set([first.fingerprint]));
+      } catch {
+        throw error;
+      }
+      logger.warn(
+        { model: parsed.model, error_type: error instanceof GatewayError ? error.code : "cursor_upstream_error" },
+        "retrying pre-semantic Cursor request on another managed account",
+      );
+      await run(alternate);
+    }
+  };
   let shuttingDown = false;
   const sweepTimer = setInterval(() => {
     try {
@@ -437,8 +530,8 @@ export function createApp(input: {
         if (body === undefined) throw invalidRequest("JSON body is required");
         const parsed = parseMessagesRequest(body);
         const sessionHint = headerValue(req, "x-cursor-session-id");
-        const auth = await resolveAuth(client, parsed, sessionHint);
-        await coordinator.handleMessages(req, res, auth, parsed, requestId, sessionHint);
+        await runWithProviderRecovery(res, client, parsed, sessionHint, (auth) =>
+          coordinator.handleMessages(req, res, auth, parsed, requestId, sessionHint));
         return;
       }
 
@@ -448,16 +541,16 @@ export function createApp(input: {
         if (body === undefined) throw invalidRequest("JSON body is required");
         const chat = parseChatCompletionsRequest(body);
         const sessionHint = headerValue(req, "x-cursor-session-id");
-        const auth = await resolveAuth(client, chat.parsed, sessionHint);
-        await coordinator.handleMessages(
-          req,
-          res,
-          auth,
-          chat.parsed,
-          requestId,
-          sessionHint,
-          createChatWriterFactory({ includeUsage: chat.includeUsage }),
-        );
+        await runWithProviderRecovery(res, client, chat.parsed, sessionHint, (auth) =>
+          coordinator.handleMessages(
+            req,
+            res,
+            auth,
+            chat.parsed,
+            requestId,
+            sessionHint,
+            createChatWriterFactory({ includeUsage: chat.includeUsage }),
+          ));
         return;
       }
 
@@ -467,16 +560,16 @@ export function createApp(input: {
         if (body === undefined) throw invalidRequest("JSON body is required");
         const responses = parseResponsesRequest(body);
         const sessionHint = headerValue(req, "x-cursor-session-id");
-        const auth = await resolveAuth(client, responses.parsed, sessionHint);
-        await coordinator.handleMessages(
-          req,
-          res,
-          auth,
-          responses.parsed,
-          requestId,
-          sessionHint,
-          createResponsesWriterFactory(),
-        );
+        await runWithProviderRecovery(res, client, responses.parsed, sessionHint, (auth) =>
+          coordinator.handleMessages(
+            req,
+            res,
+            auth,
+            responses.parsed,
+            requestId,
+            sessionHint,
+            createResponsesWriterFactory(),
+          ));
         return;
       }
 

--- a/tests/contract/health.test.ts
+++ b/tests/contract/health.test.ts
@@ -60,6 +60,9 @@ test("health reports runtime capability truth without account data", async () =>
     parallel_tools: true,
     agent_resume: true,
     pending_tool_restart_resume: false,
+    transcript_tool_recovery: true,
+    stale_auth_recovery: true,
+    managed_account_failover: true,
     streaming_impl: "sdk_onDelta",
     store_backend: "jsonl",
   });

--- a/tests/contract/messages-errors.test.ts
+++ b/tests/contract/messages-errors.test.ts
@@ -36,6 +36,32 @@ test("SDK create authentication failures map to 401 and release capacity", async
   expect(res.status).toBe(401);
   expect(body.error.type).toBe("authentication_error");
   expect(ctx.app.registry.activeCount()).toBe(0);
+  expect(ctx.sdk.credentialProbeCalls).toHaveLength(0);
+});
+
+test("stale SDK authentication retries once after the official credential probe succeeds", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      createErrorsByApiKey: {
+        "test-key-a": [{ name: "AuthenticationError", message: "authentication error" }],
+      },
+      credentialProbeByApiKey: { "test-key-a": "valid" },
+      scripts: [[{ type: "text", chunks: ["reauthenticated"] }]],
+    },
+  });
+  const response = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "hello" }],
+    }),
+  });
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as { content: Array<{ text?: string }> };
+  expect(body.content.some((item) => item.text === "reauthenticated")).toBe(true);
+  expect(ctx.sdk.createCalls).toHaveLength(2);
+  expect(ctx.sdk.credentialProbeCalls).toEqual(["test-key-a"]);
 });
 
 test("completed follow-up send failure releases the active-run slot", async () => {

--- a/tests/fixtures/fake-sdk.ts
+++ b/tests/fixtures/fake-sdk.ts
@@ -40,6 +40,8 @@ export interface FakeSdkOptions {
   finalUsage?: SdkUsage;
   liveUsage?: SdkUsage;
   createError?: { message: string; name?: string };
+  createErrorsByApiKey?: Record<string, { message: string; name?: string } | Array<{ message: string; name?: string }>>;
+  credentialProbeByApiKey?: Record<string, "valid" | "invalid" | "unavailable">;
   resumeError?: { message: string; name?: string };
 }
 
@@ -291,6 +293,7 @@ export class FakeAgent implements SdkAgent {
 export class FakeSdk implements SdkRuntime {
   readonly sdkVersion: string;
   readonly agents: FakeAgent[] = [];
+  readonly createCalls: CreateAgentInput[] = [];
   lastCreate?: CreateAgentInput;
   lastResume?: ResumeAgentInput;
   resumeCalls: ResumeAgentInput[] = [];
@@ -303,6 +306,8 @@ export class FakeSdk implements SdkRuntime {
   getAccountCalls = 0;
   readonly getAccountApiKeys: string[] = [];
   private agentScriptIndex = 0;
+  private readonly keyedCreateErrorIndexes = new Map<string, number>();
+  readonly credentialProbeCalls: string[] = [];
 
   constructor(private readonly options: FakeSdkOptions = {}) {
     this.sdkVersion = options.sdkVersion ?? "1.0.28";
@@ -327,6 +332,15 @@ export class FakeSdk implements SdkRuntime {
   }
 
   async createAgent(input: CreateAgentInput): Promise<SdkAgent> {
+    this.createCalls.push(input);
+    const configured = this.options.createErrorsByApiKey?.[input.apiKey];
+    const keyedError = Array.isArray(configured)
+      ? configured[this.keyedCreateErrorIndexes.get(input.apiKey) ?? 0]
+      : configured;
+    if (Array.isArray(configured)) {
+      this.keyedCreateErrorIndexes.set(input.apiKey, (this.keyedCreateErrorIndexes.get(input.apiKey) ?? 0) + 1);
+    }
+    if (keyedError) throw configuredError(keyedError);
     if (this.options.createError) throw configuredError(this.options.createError);
     this.lastCreate = input;
     this.lastAllowlist = apiProfileToolAllowlist(input.clientToolNames);
@@ -366,5 +380,10 @@ export class FakeSdk implements SdkRuntime {
     this.getAccountCalls += 1;
     this.getAccountApiKeys.push(apiKey);
     return this.options.accountsByApiKey?.[apiKey] ?? this.account;
+  }
+
+  async probeCredential(apiKey: string): Promise<"valid" | "invalid" | "unavailable"> {
+    this.credentialProbeCalls.push(apiKey);
+    return this.options.credentialProbeByApiKey?.[apiKey] ?? "valid";
   }
 }

--- a/tests/integration/managed-account-pool.test.ts
+++ b/tests/integration/managed-account-pool.test.ts
@@ -86,6 +86,35 @@ test("managed routing chooses an account whose live catalog contains the request
   expect(ctx.sdk.lastCreate?.apiKey).toBe("cursor-b");
 });
 
+test("pre-semantic provider failure retries once on another managed account", async () => {
+  ctx = await startTestApp({
+    config: { authMode: "managed", gatewayAccessKey: "gateway-key", managedCursorKey: undefined },
+    sdk: {
+      modelsByApiKey: {
+        "cursor-a": { ok: true, models: [{ id: "composer-2.5" }] },
+        "cursor-b": { ok: true, models: [{ id: "composer-2.5" }] },
+      },
+      createErrorsByApiKey: {
+        "cursor-a": { message: "provider connection reset before first event" },
+      },
+      agentScripts: [[[{ type: "text", chunks: ["served-by-b"] }]]],
+    },
+  });
+  await addAccount(ctx, "cursor-a");
+  await addAccount(ctx, "cursor-b");
+
+  const response = await api(ctx, "/v1/messages", {
+    apiKey: "gateway-key",
+    method: "POST",
+    body: JSON.stringify(messageBody("hello")),
+  });
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as { content: Array<{ text?: string }> };
+  expect(body.content.some((item) => item.text === "served-by-b")).toBe(true);
+  expect(ctx.sdk.createCalls.map((call) => call.apiKey)).toEqual(["cursor-a", "cursor-b"]);
+  expect(ctx.sdk.agents.map((agent) => agent.input.apiKey)).toEqual(["cursor-b"]);
+});
+
 test("managed model catalog returns the union from every configured account", async () => {
   ctx = await startTestApp({
     config: { authMode: "managed", gatewayAccessKey: "gateway-key", managedCursorKey: undefined },
@@ -286,6 +315,58 @@ test("restart recovery resolves the original account from persisted lineage", as
   });
   expect(continued.status).toBe(200);
   expect(ctx.sdk.lastResume?.apiKey).toBe("cursor-a");
+});
+
+test("full transcript cold-branches a tool continuation when its managed account was removed", async () => {
+  ctx = await startTestApp({
+    config: { authMode: "managed", gatewayAccessKey: "gateway-key", managedCursorKey: undefined },
+    sdk: {
+      modelsByApiKey: {
+        "cursor-a": { ok: true, models: [{ id: "composer-2.5" }] },
+        "cursor-b": { ok: true, models: [{ id: "composer-2.5" }] },
+      },
+      agentScripts: [
+        [[{ type: "tools", calls: [{ name: "lookup", input: { q: "weather" } }] }]],
+        [[
+          { type: "tools", calls: [{ name: "lookup", input: { q: "weather" } }] },
+          { type: "text", chunks: ["recovered-on-b"] },
+        ]],
+      ],
+    },
+  });
+  const accountA = await addAccount(ctx, "cursor-a");
+  await addAccount(ctx, "cursor-b");
+  const opened = await api(ctx, "/v1/messages", {
+    apiKey: "gateway-key",
+    method: "POST",
+    body: JSON.stringify(messageBody("use tool", [weatherTool()])),
+  });
+  const openedBody = (await opened.json()) as {
+    content: Array<{ type: string; id?: string; name?: string; input?: unknown }>;
+  };
+  const call = openedBody.content.find((item) => item.type === "tool_use");
+  expect(ctx.sdk.agents[0]?.input.apiKey).toBe("cursor-a");
+  expect(ctx.app.accounts.remove(accountA)).toBe(true);
+
+  const continued = await api(ctx, "/v1/messages", {
+    apiKey: "gateway-key",
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 64,
+      tools: [weatherTool()],
+      messages: [
+        { role: "user", content: "use tool" },
+        { role: "assistant", content: [call] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: call?.id, content: "sunny" }] },
+      ],
+    }),
+  });
+  expect(continued.status).toBe(200);
+  const body = (await continued.json()) as { content: Array<{ text?: string }> };
+  expect(body.content.some((item) => item.text === "recovered-on-b")).toBe(true);
+  expect(ctx.sdk.agents[1]?.input.apiKey).toBe("cursor-b");
+  expect(ctx.sdk.agents[1]?.runs[0]?.capturedToolResults).toEqual(["sunny"]);
 });
 
 test("completed follow-up after restart stays on its original account", async () => {

--- a/tests/integration/transcript-recovery.test.ts
+++ b/tests/integration/transcript-recovery.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, expect, test } from "vitest";
+import { api, closeTestApp, startTestApp, weatherTool, type TestContext } from "../helpers/app.js";
+
+let ctx: TestContext | undefined;
+
+afterEach(async () => {
+  if (ctx) await closeTestApp(ctx);
+  ctx = undefined;
+});
+
+test("cold-recovers an expired tool continuation from the full transcript without re-executing it", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      agentScripts: [
+        [[{ type: "tools", calls: [{ name: "lookup", input: { q: "x" } }] }]],
+        [[
+          { type: "tools", calls: [{ name: "lookup", input: { q: "x" } }] },
+          { type: "text", chunks: ["recovered"] },
+        ]],
+      ],
+    },
+  });
+  const opened = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 32,
+      tools: [weatherTool()],
+      messages: [{ role: "user", content: "look up x" }],
+    }),
+  });
+  const openedBody = (await opened.json()) as {
+    cursor_session_id: string;
+    content: Array<{ type: string; id?: string; name?: string; input?: unknown }>;
+  };
+  const call = openedBody.content.find((block) => block.type === "tool_use");
+  expect(call?.id).toBeTruthy();
+  const oldSession = ctx.app.registry.get(openedBody.cursor_session_id);
+  expect(oldSession).toBeTruthy();
+  if (oldSession) ctx.app.registry.forget(oldSession, "simulated_expiry");
+  ctx.app.lineage.delete(openedBody.cursor_session_id);
+
+  const recoveryBody = {
+    model: "composer-2.5",
+    max_tokens: 32,
+    tools: [weatherTool()],
+    messages: [
+      { role: "user", content: "look up x" },
+      { role: "assistant", content: [call] },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: call?.id, content: "cached-x" }] },
+    ],
+  };
+  const recovered = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify(recoveryBody),
+  });
+  expect(recovered.status).toBe(200);
+  const body = (await recovered.json()) as { stop_reason: string; content: Array<{ type: string; text?: string }> };
+  expect(body.stop_reason).toBe("end_turn");
+  expect(body.content.some((block) => block.text === "recovered")).toBe(true);
+  expect(ctx.sdk.agents).toHaveLength(2);
+  expect(ctx.sdk.agents[1]?.runs[0]?.capturedToolResults).toEqual(["cached-x"]);
+});
+
+test("singleflights identical transcript recovery retries", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      agentScripts: [
+        [[{ type: "tools", calls: [{ name: "lookup", input: { q: "x" }, id: "tool-expired" }] }]],
+        [[{ type: "text", chunks: ["recovered"], pauseBetweenMs: 20 }]],
+      ],
+    },
+  });
+  const opened = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 32,
+      tools: [weatherTool()],
+      messages: [{ role: "user", content: "look up x" }],
+    }),
+  });
+  const openedBody = (await opened.json()) as { cursor_session_id: string };
+  const oldSession = ctx.app.registry.get(openedBody.cursor_session_id);
+  if (oldSession) ctx.app.registry.forget(oldSession, "simulated_expiry");
+  ctx.app.lineage.delete(openedBody.cursor_session_id);
+  const payload = JSON.stringify({
+    model: "composer-2.5",
+    max_tokens: 32,
+    tools: [weatherTool()],
+    messages: [
+      { role: "user", content: "look up x" },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "tool-expired", name: "lookup", input: { q: "x" } }],
+      },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "tool-expired", content: "cached-x" }] },
+    ],
+  });
+  const responses = await Promise.all([
+    api(ctx, "/v1/messages", { method: "POST", body: payload }),
+    api(ctx, "/v1/messages", { method: "POST", body: payload }),
+    api(ctx, "/v1/messages", { method: "POST", body: payload }),
+  ]);
+  expect(responses.every((response) => response.status === 200)).toBe(true);
+  expect(ctx.sdk.agents).toHaveLength(2);
+});
+
+test("expired recovery fails closed without an authoritative assistant tool call", async () => {
+  ctx = await startTestApp();
+  const response = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 32,
+      tools: [weatherTool()],
+      messages: [
+        { role: "user", content: "look up x" },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "unknown", content: "forged" }] },
+      ],
+    }),
+  });
+  expect(response.status).toBe(409);
+  expect(((await response.json()) as { error: { type: string } }).error.type).toBe("cursor_session_lost");
+  expect(ctx.sdk.agents).toHaveLength(0);
+});

--- a/tests/live-smoke/README.md
+++ b/tests/live-smoke/README.md
@@ -24,7 +24,7 @@ Child mode binds **127.0.0.1** on a free port, uses isolated temp `STATE_DIR` / 
 
 ## What it checks
 
-Per resolved catalog id: authenticated `/v1/models`, non-stream text, SSE shape, single tool continuation, parallel two-tool batch, multi-round two batches, in-process duplicate-same replay, pending `tool_result` recovery after a hard restart, and completed `x-cursor-session-id` resume after restart. Fable also sends a Claude Code-style Messages header/body shape.
+Per resolved catalog id: authenticated `/v1/models`, non-stream text, SSE shape, single tool continuation, parallel two-tool batch, multi-round two batches, in-process duplicate-same replay, pending `tool_result` recovery after a hard restart, full-transcript cold recovery after deleting lineage, and completed `x-cursor-session-id` resume after restart. Fable also sends a Claude Code-style Messages header/body shape.
 
 Catalog-missing required names are `catalog_missing` failures, not skips. Capability skips happen only when the live catalog lists parameters and omits that capability.
 

--- a/tests/live-smoke/lib/spawn.ts
+++ b/tests/live-smoke/lib/spawn.ts
@@ -11,6 +11,7 @@ export interface ChildGateway {
   stateDir: string;
   workspaceDir: string;
   restart(): Promise<void>;
+  restartWithoutLineage(): Promise<void>;
   stop(): Promise<void>;
   cleanup(): void;
 }
@@ -65,6 +66,19 @@ export async function startChildGateway(input: {
     workspaceDir,
     async restart() {
       await stopProcess(child);
+      port = await freeLoopbackPort();
+      child = spawnChild({
+        distEntry: input.distEntry,
+        repoRoot: input.repoRoot,
+        port,
+        stateDir,
+        workspaceDir,
+      });
+      await waitHealth(`http://127.0.0.1:${port}`, readyTimeoutMs, child, input.canaries);
+    },
+    async restartWithoutLineage() {
+      await stopProcess(child);
+      rmSync(join(stateDir, "lineage"), { recursive: true, force: true });
       port = await freeLoopbackPort();
       child = spawnChild({
         distEntry: input.distEntry,

--- a/tests/live-smoke/run.ts
+++ b/tests/live-smoke/run.ts
@@ -182,6 +182,7 @@ async function runModelMatrix(
   out.push(await isolate(ctx, model, "multi_round", () => runMultiRound(ctx, model)));
   out.push(await isolate(ctx, model, "duplicate_same", () => runDuplicateSame(ctx, model)));
   out.push(await isolate(ctx, model, "pending_restart_resume", () => runPendingRestart(ctx, model)));
+  out.push(await isolate(ctx, model, "transcript_cold_recovery", () => runTranscriptColdRecovery(ctx, model)));
   out.push(await isolate(ctx, model, "completed_resume", () => runCompletedResume(ctx, model)));
   if (model.toLowerCase().includes("fable")) {
     out.push(await isolate(ctx, model, "claude_code_shape", () => runClaudeCodeShape(ctx, model)));
@@ -578,6 +579,72 @@ async function runPendingRestart(ctx: RunContext, model: string): Promise<SmokeC
   }
   return passCase(model, "pending_restart_resume", resumed, {
     duration_ms: opened.duration_ms + resumed.duration_ms,
+  });
+}
+
+async function runTranscriptColdRecovery(ctx: RunContext, model: string): Promise<SmokeCase> {
+  if (!ctx.child) {
+    return {
+      id: `${model}/transcript_cold_recovery`,
+      model,
+      case: "transcript_cold_recovery",
+      status: "not_run",
+      required: true,
+      reason: "attach_mode_no_process_control",
+    };
+  }
+  const promptMarker = opaqueMarker("cold-call");
+  const userPrompt = `Call live_alpha once with token ${promptMarker}. Do not answer in text first.`;
+  const opened = await postMessages({
+    baseUrl: ctx.baseUrl,
+    apiKey: ctx.apiKey,
+    timeoutMs: ctx.timeoutMs,
+    body: {
+      model,
+      max_tokens: 256,
+      tools: liveTools(),
+      messages: [{ role: "user", content: userPrompt }],
+    },
+  });
+  const raw = opened.raw as { content?: Array<Record<string, unknown>> };
+  const call = raw.content?.find((block) => block.type === "tool_use");
+  if (opened.status !== 200 || !call || typeof call.id !== "string" || typeof call.name !== "string") {
+    return failCase(model, "transcript_cold_recovery", { ...opened, reason: "no_tool_use" });
+  }
+  await ctx.child.restartWithoutLineage();
+  ctx.baseUrl = ctx.child.baseUrl;
+  const marker = opaqueMarker("cold-result");
+  const recovered = await postMessages({
+    baseUrl: ctx.baseUrl,
+    apiKey: ctx.apiKey,
+    timeoutMs: ctx.timeoutMs,
+    marker,
+    body: {
+      model,
+      max_tokens: 128,
+      tools: liveTools(),
+      messages: [
+        { role: "user", content: userPrompt },
+        { role: "assistant", content: [call] },
+        {
+          role: "user",
+          content: [{
+            type: "tool_result",
+            tool_use_id: call.id,
+            content: `The result is ${marker}. Reply with exactly ${marker}.`,
+          }],
+        },
+      ],
+    },
+  });
+  if (recovered.status !== 200 || recovered.error_type || !recovered.marker_hit) {
+    return failCase(model, "transcript_cold_recovery", {
+      ...recovered,
+      reason: recovered.marker_hit ? recovered.error_type : "cold_recovery_marker_missing",
+    });
+  }
+  return passCase(model, "transcript_cold_recovery", recovered, {
+    duration_ms: opened.duration_ms + recovered.duration_ms,
   });
 }
 


### PR DESCRIPTION
## What changed

- recover stale Cursor SDK authentication once after an official credential probe
- fail over pre-semantic managed requests to one alternate compatible account
- cold-rebuild expired or moved tool continuations from an exact full transcript
- replay completed tool signatures internally to avoid repeated client side effects
- add deterministic and real Sonnet 4.6 / Grok 4.6 recovery acceptance
- bump the package release to v0.2.0

## Boundaries

BeefAPI billing, channel distribution, peer-routing control plane, and cross-channel model caches remain outside this standalone gateway. No retry occurs after response output begins, and incomplete parallel tool batches remain fail-closed.

## Verification

- `npm test` — 189/189
- `npm run typecheck`
- `npm run build`
- Docker image build
- Git-history gitleaks scan — no leaks
- official Cursor SDK live matrix: Sonnet 4.6 + Grok 4.6 xhigh, `required_failures=0`
