### PR TITLE
docs: always load repository rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 This file is intentionally thin.
 
-1. Read `BFLABS.md` completely before non-trivial work. It contains this repository's rules.
+1. Read `BFLABS.md` completely before any task. It contains this repository's rules.
 2. Use `README.md` for product and setup orientation.
 3. Use `docs/INDEX.md` when it exists and the owning module, specification, test, or runbook is not already known.
 4. Use the active issue, specification, task packet, and pull request for change-specific scope and acceptance.


### PR DESCRIPTION
## What changed

The thin root `AGENTS.md` now requires coding agents to read this repository's `BFLABS.md` before any task, instead of only before work the agent considers non-trivial.

## Why

`non-trivial` is subjective. An agent could classify a small documentation, formatting, or wording change as trivial and skip repository rules that still apply to that task. Loading `BFLABS.md` unconditionally closes that governance gap.

## Scope

- one wording change in `AGENTS.md`;
- this repository's independent `BFLABS.md` content is unchanged;
- no runtime, dependency, deployment, release, data, credential, or payment behavior changed.

## Validation

- `git diff --check` passed;
- `AGENTS.md` contains `Read BFLABS.md completely before any task`;
- the old `before non-trivial work` condition is absent.
