### PR TITLE
Reuse durable Cursor Agents for exact ordinary follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Ordinary turns now follow BeefAPI's Cursor Agent contract: a typed turn IR, exact-lineage Agent reuse, and `send(current turn)` instead of flattening the whole transcript on every request. Tool continuation, `x-cursor-session-id` follow-up, and cold rebuild remain. Disable with `ORDINARY_TURN_COORDINATOR=0`.
+
 - `/v1/messages` accepts sub2api compatibility roles without flattening the transcript: `system`/`developer` remain in order, historical `tool`/`function` output stays visible to the Harness, and a trailing tool result requires a real call id before entering continuation lookup.
 - `/v1/responses` accepts `text.format.type=json_schema` as an explicit Harness output contract instead of silently dropping it. Client-executed function, custom/freeform, and namespace declarations inside `input[].type=additional_tools` join the real MCP tool catalog; a same-name top-level declaration is authoritative, matching Codex Responses Lite. Custom calls use native `custom_tool_call` events and namespace identities are restored on output. Conflicts within one additional catalog and provider-hosted tool shapes still fail closed.
 - `/v1/account` now reads current-period spending, remaining included usage, model-family percentages, plan metadata, and limits through Cursor Dashboard using the same User API Key, without Cookie or Team Admin credentials. Missing usage remains a partial response rather than a fabricated zero quota.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 - **Claude 1M mode:** when Cursor's live catalog exposes `context=1m`, including on Sonnet 4.6 and Fable 5, the official SDK parameter is forwarded unchanged.
 - **Native client tools:** filesystem, shell, web, and network tools stay in Claude Code, Grok, or Codex and run in your local workspace.
-- **One tool engine:** all three protocols share the same Cursor SDK run, parallel-tool, continuation, replay, and session coordinator.
+- **One tool engine:** all three protocols share the same Cursor SDK run, parallel-tool, continuation, replay, and session coordinator. Ordinary follow-up with a complete transcript reuses one durable Agent and sends only the current user turn.
 - **One gateway key, many accounts:** persistent Cursor account pool, model-aware round-robin, stale SDK-auth recovery, pre-semantic account failover, Dashboard quota, web console, and Docker.
 - **Cold continuation recovery:** a complete client transcript can rebuild an expired or moved tool turn while replaying already-completed tools locally instead of executing their side effects twice.
 - **new-api integrated:** ready-made external deployment, channel templates, compose E2E, and acceptance smoke. [Open the new-api guide](docs/NEW_API_INTEGRATION.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,7 +29,7 @@
 
 - **Claude 1M 模式：** Cursor 实时目录暴露 `context=1m` 时，包括 Sonnet 4.6、Fable 5，网关会把官方 SDK 参数原样转发。
 - **客户端原生工具：** 文件、shell、网页和网络工具仍由 Claude Code、Grok 或 Codex 在你的本机工作区执行。
-- **一套工具引擎：** 三种协议共用同一个 Cursor SDK Run、并行工具、续轮、replay 和 session coordinator。
+- **一套工具引擎：** 三种协议共用同一个 Cursor SDK Run、并行工具、续轮、replay 和 session coordinator。带完整 transcript 的普通下一轮会复用同一个 durable Agent，并且只 `send` 当前用户回合。
 - **一把网关 Key，多账号共用：** Cursor 账号池持久化、按模型 round-robin、SDK 陈旧登录态恢复、语义输出前账号故障转移、Dashboard 额度、Web 控制台和 Docker。
 - **续轮冷恢复：** 客户端携带完整 transcript 时，可以重建过期或迁移的工具轮；已经执行过的同一工具由网关内部回放结果，不重复产生副作用。
 - **已集成 new-api：** 已提供外置部署、渠道模板、compose E2E 和验收 smoke。[直接查看 new-api 接入指南](docs/NEW_API_INTEGRATION.md)。

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,7 +7,11 @@ One live SDK Run has one owner process and one event-pump consumer.
 ```
 HTTP /v1/messages | /v1/chat/completions | /v1/responses
   -> protocol parse (Chat/Responses convert to canonical ParsedMessages)
+  -> CursorAgentTurn (protocol-neutral ordinary-turn IR)
   -> RunCoordinator
+       -> tool_result: existing ATTACH / lineage resume / transcript recovery
+       -> exact successor: Agent.resume/send(current turn text+images only)
+       -> unknown/fork/compact: cold rebuild with full transcript fallback
        -> SessionRegistry (fingerprint, model, tool_use_id, TTL)
        -> ToolBridge (request tools -> local.customTools)
        -> EventPump (single run.stream() consumer for tool/status/terminal)
@@ -46,7 +50,9 @@ Pending calls live in a `Map<toolUseId, PendingCall>`. There is no single-pendin
 
 SDK Agent history lives in credential-partitioned `$STATE_DIR/sdk-store/<fingerprint>` directories via the official `JsonlLocalAgentStore`. Each credential also receives a private empty-workspace partition. Gateway lineage (`$STATE_DIR/lineage`) keeps only resume metadata: session id, SDK agent id, credential fingerprint, model and explicit model parameters, state, pending tool ids, optional result digest, and timestamps.
 
-Completed follow-up with `x-cursor-session-id` looks up lineage, checks fingerprint/model, then `Agent.resume` + `send` on that same store. Pending callback Promises are not serialized; the lineage stores only tool ids and names. After owner death, an exact credential/model/tool-id batch resumes the persisted Agent and sends a synthetic host-recovery turn with `local.force=true`. Concurrent duplicate-same recovery is singleflight. Assistant replay bodies are not persisted, so duplicate-same after a later process restart still has no persisted response body.
+Ordinary multi-turn requests without `x-cursor-session-id` use a credential-free journal of digests (`STATE_DIR/ordinary-turns.json`). Exact linear successors reuse the same Agent and `send()` only the latest user text/images. Forks, compact/missing anchors, model/effort/tool-catalog mismatches, and credential rotation cold-rebuild. Identical request digests replay in-process; after a process restart they fail closed because assistant bodies are not persisted.
+
+Completed follow-up with `x-cursor-session-id` looks up lineage, checks fingerprint/model, then `Agent.resume` + `send` on that same store. `ORDINARY_TURN_COORDINATOR=0` restores the previous flatten-every-turn path. Pending callback Promises are not serialized; the lineage stores only tool ids and names. After owner death, an exact credential/model/tool-id batch resumes the persisted Agent and sends a synthetic host-recovery turn with `local.force=true`. Concurrent duplicate-same recovery is singleflight. Assistant replay bodies are not persisted, so duplicate-same after a later process restart still has no persisted response body.
 
 When no exact live or persisted owner can attach, tool continuation may cold-branch only from a self-contained transcript. The latest assistant tool batch must exactly match the submitted result ids and every call must exist in the request catalog. Historical completed calls are indexed by stable tool-name/input signature; if the recovered Harness requests one again, the gateway returns the recorded result internally rather than exposing the same side effect to the client twice. Identical recovery requests are singleflight and replayable for the normal replay TTL.
 

--- a/docs/PROTOCOL_COMPATIBILITY.md
+++ b/docs/PROTOCOL_COMPATIBILITY.md
@@ -24,6 +24,7 @@ Outer agents (Claude Code, Grok Build) execute their own local file tools in the
 | tool continuation | yes | Latest user turn must be only `tool_result` |
 | mixed text + tool_result | no | `422 invalid_request` |
 | usage / cache | pass-through | Final-only cumulative; omit missing fields |
+| ordinary next turn without session header | yes | Exact transcript lineage reuses the Agent and sends only the current user turn. Unknown, forked, compacted, or mismatched requests cold-rebuild. `ORDINARY_TURN_COORDINATOR=0` disables this. |
 | completed `x-cursor-session-id` follow-up | yes | Store + `Agent.resume` within TTL |
 | pending tool restart | yes | Exact credential/model/tool batch resumes with persisted SDK Agent lineage and `local.force=true` |
 | expired/moved tool continuation | yes | A complete transcript whose latest assistant tool batch exactly matches the submitted results can cold-branch to a new SDK Agent; recorded identical tools replay internally |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor-sdk2api",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Independent MIT gateway that exposes official @cursor/sdk as Anthropic- and OpenAI-compatible HTTP APIs.",
   "license": "MIT",
   "type": "module",
@@ -36,6 +36,7 @@
     "dev:web": "vite --config web/vite.config.ts",
     "lint": "npm run typecheck",
     "live:smoke": "tsx tests/live-smoke/run.ts",
+    "live:ordinary": "tsx tests/live-smoke/ordinary-turn-live.ts",
     "new-api:smoke": "node integrations/new-api/smoke.mjs",
     "secret:scan": "bash tests/secret-scan.sh"
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,7 @@ export interface GatewayConfig {
   replayTtlMs: number;
   runDeadlineMs: number;
   firstEventTimeoutMs: number;
+  ordinaryTurnCoordinator: boolean;
   toolBatchSettleMs: number;
   catalogCacheMs: number;
   sweepIntervalMs: number;
@@ -53,6 +54,7 @@ export interface RuntimeCapabilities {
   transcript_tool_recovery?: boolean;
   stale_auth_recovery?: boolean;
   managed_account_failover?: boolean;
+  ordinary_turn_coordinator?: boolean;
   streaming_impl?: "sdk_onDelta";
   store_backend?: "jsonl";
 }
@@ -73,9 +75,19 @@ export const DEFAULT_CAPABILITIES: RuntimeCapabilities = {
   transcript_tool_recovery: true,
   stale_auth_recovery: true,
   managed_account_failover: true,
+  ordinary_turn_coordinator: true,
   streaming_impl: "sdk_onDelta",
   store_backend: "jsonl",
 };
+
+function envBool(name: string, fallback: boolean): boolean {
+  const raw = process.env[name];
+  if (raw == null || raw === "") return fallback;
+  const value = raw.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(value)) return true;
+  if (["0", "false", "no", "off"].includes(value)) return false;
+  throw new Error(`Environment variable ${name} must be a boolean`);
+}
 
 function envInt(name: string, fallback: number): number {
   const raw = process.env[name];
@@ -115,6 +127,10 @@ export function loadConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfi
     replayTtlMs: envInt("REPLAY_TTL_MS", 10 * 60_000),
     runDeadlineMs: envInt("RUN_DEADLINE_MS", 60 * 60_000),
     firstEventTimeoutMs: envInt("FIRST_EVENT_TIMEOUT_MS", 40_000),
+    ordinaryTurnCoordinator: envBool(
+      "ORDINARY_TURN_COORDINATOR",
+      envBool("CURSOR_AGENT_TURN_COORDINATOR", true),
+    ),
     toolBatchSettleMs: envInt("TOOL_BATCH_SETTLE_MS", 1_500),
     catalogCacheMs: envInt("CATALOG_CACHE_MS", 5 * 60_000),
     sweepIntervalMs: envInt("SWEEP_INTERVAL_MS", 5_000),
@@ -138,5 +154,13 @@ export function loadConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfi
     }
   }
 
-  return { ...config, ...overrides, capabilities: { ...config.capabilities, ...overrides.capabilities } };
+  const merged = { ...config, ...overrides };
+  return {
+    ...merged,
+    capabilities: {
+      ...config.capabilities,
+      ordinary_turn_coordinator: merged.ordinaryTurnCoordinator,
+      ...overrides.capabilities,
+    },
+  };
 }

--- a/src/core/cursor-agent-turn.ts
+++ b/src/core/cursor-agent-turn.ts
@@ -1,0 +1,240 @@
+import { digestJson, sha256Hex, stableStringify } from "../digest.js";
+import { asBlocks, collectImages } from "../protocols/anthropic/parse.js";
+import type {
+  AnthropicContentBlock,
+  AnthropicMessage,
+  AnthropicTool,
+  ParsedMessages,
+} from "../protocols/anthropic/types.js";
+import type { ToolChoicePolicy } from "../protocols/tool-choice.js";
+
+export const CURSOR_AGENT_TURN_VERSION = 1;
+export const CURSOR_AGENT_ROUTE = "cursor-agent";
+
+export interface CursorAgentTurn {
+  version: number;
+  sourceProtocol: string;
+  stream: boolean;
+  tenantScope: string;
+  channelId: number;
+  route: string;
+  originalModel: string;
+  effectiveModel: string;
+  system: string;
+  conversation: AnthropicMessage[];
+  tools: AnthropicTool[];
+  toolChoice: ToolChoicePolicy | null;
+  currentTurn: {
+    text: string;
+    images: Array<{ data: string; mimeType: string }>;
+  };
+  continuationToolIds: string[];
+  lineage: {
+    requestDigest: string;
+    parentAssistantAnchor: string;
+    turnIndex: number;
+    toolCatalogDigest: string;
+  };
+}
+
+export function effectiveCursorModel(
+  model: string,
+  modelParams: Array<{ id: string; value: string }>,
+): string {
+  return `${model}|${stableStringify(modelParams)}`;
+}
+
+export function serializedContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const item = block as AnthropicContentBlock;
+    if (item.type === "text" && typeof item.text === "string") {
+      parts.push(item.text);
+    } else if (item.type === "thinking" && typeof item.thinking === "string") {
+      parts.push(item.thinking);
+    } else if (item.type === "tool_use" && item.id && item.name) {
+      parts.push(`TOOL_USE id=${item.id} name=${item.name} input=${JSON.stringify(item.input ?? {})}`);
+    } else if (item.type === "tool_result" && item.tool_use_id) {
+      parts.push(
+        `TOOL_RESULT tool_use_id=${item.tool_use_id} is_error=${Boolean(item.is_error)} content=${JSON.stringify(stringifyUnknown(item.content))}`,
+      );
+    } else if (item.type === "image") {
+      parts.push("IMAGE_ATTACHMENT");
+    }
+  }
+  return parts.join("\n");
+}
+
+export function digestAssistantAnchor(content: unknown): string {
+  return sha256Hex(serializedContent(content));
+}
+
+export function normalizeTools(tools: AnthropicTool[] | undefined): AnthropicTool[] {
+  if (!Array.isArray(tools)) return [];
+  const normalized: AnthropicTool[] = [];
+  for (const tool of tools) {
+    const name = String(tool?.name || "").trim();
+    if (!name) continue;
+    normalized.push({
+      name,
+      description: typeof tool.description === "string" ? tool.description : "",
+      input_schema:
+        tool.input_schema && typeof tool.input_schema === "object"
+          ? tool.input_schema
+          : { type: "object", properties: {} },
+    });
+  }
+  return normalized;
+}
+
+export function digestToolCatalog(tools: AnthropicTool[] | undefined): string {
+  return digestJson(normalizeTools(tools));
+}
+
+export function imageDigests(images: Array<{ data: string; mimeType: string }>): string[] {
+  return images.map((image) => sha256Hex(`data:${image.mimeType}:${image.data}`));
+}
+
+export function textFromContent(content: string | AnthropicContentBlock[] | undefined): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((block): block is Extract<AnthropicContentBlock, { type: "text" }> => block.type === "text")
+    .map((block) => block.text)
+    .join("\n");
+}
+
+export function currentTurnFromMessage(message: AnthropicMessage | undefined): {
+  text: string;
+  images: Array<{ data: string; mimeType: string }>;
+} {
+  if (!message) return { text: "", images: [] };
+  const text =
+    typeof message.content === "string"
+      ? message.content.trim()
+      : textFromContent(asBlocks(message.content)).trim();
+  return {
+    text,
+    images: collectImages([message]),
+  };
+}
+
+function lastUserIndex(conversation: AnthropicMessage[]): number {
+  for (let index = conversation.length - 1; index >= 0; index -= 1) {
+    if (conversation[index]?.role === "user") return index;
+  }
+  return -1;
+}
+
+function parentAssistantMessage(
+  conversation: AnthropicMessage[],
+  userIndex: number,
+): AnthropicMessage | null {
+  for (let index = userIndex - 1; index >= 0; index -= 1) {
+    if (conversation[index]?.role === "assistant") return conversation[index] ?? null;
+  }
+  return null;
+}
+
+export function digestCursorAgentTurnRequest(turn: CursorAgentTurn): string {
+  return digestJson({
+    effectiveModel: turn.effectiveModel,
+    currentTurnText: turn.currentTurn.text,
+    currentTurnImages: imageDigests(turn.currentTurn.images),
+    toolCatalogDigest: turn.lineage.toolCatalogDigest,
+    toolChoice: turn.toolChoice,
+    parentAssistantAnchor: turn.lineage.parentAssistantAnchor,
+    turnIndex: turn.lineage.turnIndex,
+  });
+}
+
+export function cursorAgentTurnLineageKey(turn: CursorAgentTurn): string {
+  return digestJson({
+    tenantScope: turn.tenantScope,
+    route: turn.route,
+    channelId: turn.channelId,
+    effectiveModel: turn.effectiveModel,
+    parentAssistantAnchor: turn.lineage.parentAssistantAnchor,
+    turnIndex: turn.lineage.turnIndex,
+    toolCatalogDigest: turn.lineage.toolCatalogDigest,
+  });
+}
+
+export function nextCursorAgentTurnLineageKey(turn: CursorAgentTurn, assistantAnchor: string): string {
+  return digestJson({
+    tenantScope: turn.tenantScope,
+    route: turn.route,
+    channelId: turn.channelId,
+    effectiveModel: turn.effectiveModel,
+    parentAssistantAnchor: assistantAnchor,
+    turnIndex: turn.lineage.turnIndex + 1,
+    toolCatalogDigest: turn.lineage.toolCatalogDigest,
+  });
+}
+
+export function cursorAgentTurnFromParsed(
+  parsed: ParsedMessages,
+  extras: { tenantScope: string; sourceProtocol?: string } = { tenantScope: "" },
+): CursorAgentTurn {
+  const conversation = parsed.messages;
+  const userIndex = lastUserIndex(conversation);
+  const currentMessage = userIndex >= 0 ? conversation[userIndex] : undefined;
+  const parent = userIndex >= 0 ? parentAssistantMessage(conversation, userIndex) : null;
+  const tools = normalizeTools(parsed.tools);
+  const currentTurn = currentTurnFromMessage(currentMessage);
+  const turnIndex = conversation.filter((message) => message.role === "user").length;
+  const toolCatalogDigest = digestToolCatalog(tools);
+  const turn: CursorAgentTurn = {
+    version: CURSOR_AGENT_TURN_VERSION,
+    sourceProtocol: extras.sourceProtocol || "messages",
+    stream: parsed.stream,
+    tenantScope: extras.tenantScope,
+    channelId: 0,
+    route: CURSOR_AGENT_ROUTE,
+    originalModel: parsed.model,
+    effectiveModel: effectiveCursorModel(parsed.model, parsed.modelParams),
+    system: parsed.systemText,
+    conversation,
+    tools,
+    toolChoice: parsed.toolChoice ?? null,
+    currentTurn,
+    continuationToolIds: (parsed.continuation ?? []).map((result) => result.toolUseId),
+    lineage: {
+      requestDigest: "",
+      parentAssistantAnchor: parent ? digestAssistantAnchor(parent.content) : "",
+      turnIndex,
+      toolCatalogDigest,
+    },
+  };
+  turn.lineage.requestDigest = digestCursorAgentTurnRequest(turn);
+  return turn;
+}
+
+export function currentTurnSendPayload(turn: CursorAgentTurn): {
+  text: string;
+  images: Array<{ data: string; mimeType: string }>;
+} {
+  const images = turn.currentTurn.images;
+  const text = turn.currentTurn.text.trim();
+  return {
+    text: text || " ",
+    images,
+  };
+}
+
+export function ordinaryReplayKey(turn: CursorAgentTurn): string {
+  return `${cursorAgentTurnLineageKey(turn)}:${turn.lineage.requestDigest}`;
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value == null) return "";
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/src/core/ordinary-turn-journal.ts
+++ b/src/core/ordinary-turn-journal.ts
@@ -1,0 +1,221 @@
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+export const ORDINARY_TURN_SCHEMA_VERSION = 1;
+
+export type OrdinaryTurnState = "running" | "completed";
+
+export interface OrdinaryTurnRecord {
+  lineageKey: string;
+  requestDigest: string;
+  nextLineageKey: string;
+  tenantScope: string;
+  route: string;
+  channelId: number;
+  effectiveModel: string;
+  parentAssistantAnchor: string;
+  turnIndex: number;
+  toolCatalogDigest: string;
+  assistantAnchor: string;
+  agentId: string;
+  credentialFingerprint: string;
+  state: OrdinaryTurnState;
+  createdAt: number;
+  updatedAt: number;
+  expiresAt: number;
+}
+
+const ALLOWED_STATES = new Set<OrdinaryTurnState>(["running", "completed"]);
+const FORBIDDEN_KEYS = [
+  "prompt",
+  "transcript",
+  "messages",
+  "conversation",
+  "tools",
+  "images",
+  "response",
+  "content",
+  "apiKey",
+  "credential",
+  "body",
+] as const;
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function validateRecord(record: OrdinaryTurnRecord): void {
+  if (!record || typeof record !== "object") {
+    throw new Error("invalid Cursor ordinary-turn record");
+  }
+  if (!record.lineageKey || !record.requestDigest || !record.effectiveModel) {
+    throw new Error("incomplete Cursor ordinary-turn record");
+  }
+  if (record.tenantScope && !/^[a-f0-9]{64}$/.test(record.tenantScope)) {
+    throw new Error("invalid Cursor ordinary-turn tenant scope");
+  }
+  if (!ALLOWED_STATES.has(record.state)) {
+    throw new Error("unsupported Cursor ordinary-turn record state");
+  }
+  if (!Number.isFinite(record.expiresAt)) {
+    throw new Error("Cursor ordinary-turn record requires expiry");
+  }
+  if (record.credentialFingerprint && !/^[a-f0-9]{64}$/.test(record.credentialFingerprint)) {
+    throw new Error("invalid Cursor ordinary-turn credential fingerprint");
+  }
+  for (const key of FORBIDDEN_KEYS) {
+    if (Object.hasOwn(record, key)) {
+      throw new Error("Cursor ordinary-turn journal cannot persist request or response content");
+    }
+  }
+}
+
+export class OrdinaryTurnJournal {
+  readonly records = new Map<string, OrdinaryTurnRecord>();
+  private onExpire?: (record: OrdinaryTurnRecord) => void;
+
+  constructor(
+    readonly filePath = "",
+    private readonly options: {
+      now?: () => number;
+      onExpire?: (record: OrdinaryTurnRecord) => void;
+    } = {},
+  ) {
+    this.onExpire = options.onExpire;
+    this.#load();
+  }
+
+  setOnExpire(handler: (record: OrdinaryTurnRecord) => void): void {
+    this.onExpire = handler;
+  }
+
+  now(): number {
+    return this.options.now?.() ?? Date.now();
+  }
+
+  #recordId(record: Pick<OrdinaryTurnRecord, "lineageKey" | "requestDigest">): string {
+    return `${record.lineageKey}:${record.requestDigest}`;
+  }
+
+  #load(): void {
+    if (!this.filePath) return;
+    let parsed: { schemaVersion?: number; records?: OrdinaryTurnRecord[] };
+    try {
+      parsed = JSON.parse(readFileSync(this.filePath, "utf8")) as {
+        schemaVersion?: number;
+        records?: OrdinaryTurnRecord[];
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code === "ENOENT") return;
+      throw new Error(
+        `failed to load Cursor ordinary-turn journal: ${error instanceof Error ? error.message : error}`,
+      );
+    }
+    if (parsed.schemaVersion !== ORDINARY_TURN_SCHEMA_VERSION || !Array.isArray(parsed.records)) {
+      throw new Error("unsupported Cursor ordinary-turn journal schema");
+    }
+    const expired: OrdinaryTurnRecord[] = [];
+    for (const record of parsed.records) {
+      validateRecord(record);
+      if (record.expiresAt > this.now()) this.records.set(this.#recordId(record), record);
+      else expired.push(record);
+    }
+    this.#flush();
+    this.#notifyExpired(expired);
+  }
+
+  #flush(): void {
+    if (!this.filePath) return;
+    mkdirSync(dirname(this.filePath), { recursive: true });
+    const temporary = `${this.filePath}.${process.pid}.tmp`;
+    writeFileSync(
+      temporary,
+      `${JSON.stringify({ schemaVersion: ORDINARY_TURN_SCHEMA_VERSION, records: [...this.records.values()] })}\n`,
+      { mode: 0o600 },
+    );
+    renameSync(temporary, this.filePath);
+  }
+
+  upsert(record: OrdinaryTurnRecord): OrdinaryTurnRecord {
+    validateRecord(record);
+    this.records.set(this.#recordId(record), clone(record));
+    this.#flush();
+    return clone(record);
+  }
+
+  remove(lineageKey: string, requestDigest: string): boolean {
+    if (!this.records.delete(`${lineageKey}:${requestDigest}`)) return false;
+    this.#flush();
+    return true;
+  }
+
+  findExact(lineageKey: string, requestDigest: string): OrdinaryTurnRecord | null {
+    this.sweepExpired();
+    const record = this.records.get(`${lineageKey}:${requestDigest}`);
+    return record ? clone(record) : null;
+  }
+
+  findByLineageKey(lineageKey: string): OrdinaryTurnRecord[] {
+    this.sweepExpired();
+    return [...this.records.values()]
+      .filter((record) => record.lineageKey === lineageKey)
+      .map(clone);
+  }
+
+  findByNextLineageKey(nextLineageKey: string): OrdinaryTurnRecord[] {
+    this.sweepExpired();
+    return [...this.records.values()]
+      .filter((record) => record.state === "completed" && record.nextLineageKey === nextLineageKey)
+      .map(clone);
+  }
+
+  sweepExpired(): boolean {
+    const now = this.now();
+    const expired: OrdinaryTurnRecord[] = [];
+    let changed = false;
+    for (const [id, record] of this.records) {
+      if (record.expiresAt <= now) {
+        this.records.delete(id);
+        expired.push(record);
+        changed = true;
+      }
+    }
+    if (changed) this.#flush();
+    this.#notifyExpired(expired);
+    return changed;
+  }
+
+  counts(): { running: number; completed: number; total: number } {
+    this.sweepExpired();
+    let running = 0;
+    let completed = 0;
+    for (const record of this.records.values()) {
+      if (record.state === "running") running += 1;
+      else completed += 1;
+    }
+    return { running, completed, total: running + completed };
+  }
+
+  clear(): void {
+    this.records.clear();
+    if (this.filePath) rmSync(this.filePath, { force: true });
+  }
+
+  #notifyExpired(expired: OrdinaryTurnRecord[]): void {
+    if (!this.onExpire || expired.length === 0) return;
+    const liveAgentIds = new Set(
+      [...this.records.values()].map((record) => record.agentId).filter(Boolean),
+    );
+    const notified = new Set<string>();
+    for (const record of expired) {
+      const agentId = record.agentId;
+      if (!agentId || liveAgentIds.has(agentId) || notified.has(agentId)) continue;
+      notified.add(agentId);
+      try {
+        this.onExpire(record);
+      } catch {
+        // Store cleanup is best-effort; journal expiry already landed.
+      }
+    }
+  }
+}

--- a/src/core/ordinary-turn.ts
+++ b/src/core/ordinary-turn.ts
@@ -1,0 +1,108 @@
+import {
+  cursorAgentTurnLineageKey,
+  ordinaryReplayKey,
+  type CursorAgentTurn,
+} from "./cursor-agent-turn.js";
+import type { OrdinaryTurnJournal, OrdinaryTurnRecord } from "./ordinary-turn-journal.js";
+
+export type OrdinaryTurnDecision =
+  | { action: "tool_continuation"; reason: "legacy_tool_result" }
+  | { action: "replay"; reason: "identical_digest"; record: OrdinaryTurnRecord }
+  | { action: "fail_closed"; reason: "completed_without_in_memory_response"; record: OrdinaryTurnRecord }
+  | {
+      action: "singleflight";
+      reason: "identical_digest" | "identical_digest_running";
+      lineageKey: string;
+      requestDigest: string;
+      record?: OrdinaryTurnRecord;
+    }
+  | {
+      action: "resume";
+      reason: "exact_successor";
+      record: OrdinaryTurnRecord;
+    }
+  | {
+      action: "rebuild";
+      reason:
+        | "coordinator_disabled"
+        | "concurrent_successor_fork"
+        | "fork"
+        | "ambiguous_parent"
+        | "lineage_mismatch"
+        | "expired"
+        | "unknown_or_first";
+      record?: OrdinaryTurnRecord;
+    };
+
+export function decideOrdinaryTurn(input: {
+  turn: CursorAgentTurn;
+  journal: OrdinaryTurnJournal;
+  inflight: ReadonlySet<string>;
+  now: number;
+  enabled: boolean;
+  hasReplay: boolean;
+}): OrdinaryTurnDecision {
+  const { turn, journal, inflight, now, enabled, hasReplay } = input;
+  if (!enabled) return { action: "rebuild", reason: "coordinator_disabled" };
+  if (turn.continuationToolIds.length > 0) {
+    return { action: "tool_continuation", reason: "legacy_tool_result" };
+  }
+
+  journal.sweepExpired();
+  const lineageKey = cursorAgentTurnLineageKey(turn);
+  const requestDigest = turn.lineage.requestDigest;
+  const key = ordinaryReplayKey(turn);
+  if (inflight.has(key)) {
+    return { action: "singleflight", reason: "identical_digest", lineageKey, requestDigest };
+  }
+
+  const exact = journal.findExact(lineageKey, requestDigest);
+  if (exact?.state === "completed") {
+    if (hasReplay) return { action: "replay", reason: "identical_digest", record: exact };
+    return { action: "fail_closed", reason: "completed_without_in_memory_response", record: exact };
+  }
+  if (exact?.state === "running") {
+    return {
+      action: "singleflight",
+      reason: "identical_digest_running",
+      lineageKey,
+      requestDigest,
+      record: exact,
+    };
+  }
+
+  const sameParent = journal.findByLineageKey(lineageKey);
+  const runningOther = sameParent.find(
+    (record) => record.state === "running" && record.requestDigest !== requestDigest,
+  );
+  if (runningOther) {
+    return { action: "rebuild", reason: "concurrent_successor_fork", record: runningOther };
+  }
+  const completedOther = sameParent.find(
+    (record) => record.state === "completed" && record.requestDigest !== requestDigest,
+  );
+  if (completedOther) {
+    return { action: "rebuild", reason: "fork", record: completedOther };
+  }
+
+  const successors = journal.findByNextLineageKey(lineageKey);
+  if (successors.length > 1) {
+    return { action: "rebuild", reason: "ambiguous_parent" };
+  }
+  if (successors.length === 1) {
+    const parent = successors[0]!;
+    if (
+      parent.tenantScope !== turn.tenantScope ||
+      parent.effectiveModel !== turn.effectiveModel ||
+      parent.toolCatalogDigest !== turn.lineage.toolCatalogDigest ||
+      Number(parent.channelId || 0) !== Number(turn.channelId || 0)
+    ) {
+      return { action: "rebuild", reason: "lineage_mismatch", record: parent };
+    }
+    if (parent.expiresAt <= now) {
+      return { action: "rebuild", reason: "expired", record: parent };
+    }
+    return { action: "resume", reason: "exact_successor", record: parent };
+  }
+  return { action: "rebuild", reason: "unknown_or_first" };
+}

--- a/src/core/run-coordinator.ts
+++ b/src/core/run-coordinator.ts
@@ -1,3 +1,5 @@
+import { appendFileSync } from "node:fs";
+import { join } from "node:path";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Clock } from "../clock.js";
 import type { GatewayConfig } from "../config.js";
@@ -15,7 +17,18 @@ import type { ParsedMessages, ParsedToolResult } from "../protocols/anthropic/ty
 import { renderPrompt } from "../protocols/anthropic/parse.js";
 import { createAnthropicWriter } from "../protocols/anthropic/writer.js";
 import type { SdkDeltaUpdate, SdkRuntime } from "../sdk/port.js";
+import {
+  currentTurnSendPayload,
+  cursorAgentTurnFromParsed,
+  cursorAgentTurnLineageKey,
+  digestAssistantAnchor,
+  nextCursorAgentTurnLineageKey,
+  ordinaryReplayKey,
+  type CursorAgentTurn,
+} from "./cursor-agent-turn.js";
 import { EventPump, type PumpBoundary } from "./event-pump.js";
+import { decideOrdinaryTurn } from "./ordinary-turn.js";
+import type { OrdinaryTurnJournal, OrdinaryTurnRecord } from "./ordinary-turn-journal.js";
 import { Session } from "./session.js";
 import { SessionRegistry } from "./session-registry.js";
 import { batchDigest, mapClientTools } from "./tool-bridge.js";
@@ -31,6 +44,7 @@ export interface CoordinatorDeps {
   logger: Logger;
   workspaceDir: string;
   lineage?: LineageStore;
+  ordinaryJournal?: OrdinaryTurnJournal;
   /** Test-only gate between waitForBoundary and state transition. */
   beforeApplyBoundary?: (boundary: PumpBoundary) => Promise<void>;
 }
@@ -83,8 +97,15 @@ export class RunCoordinator {
     string,
     { expiresAt: number; promise: Promise<{ session: Session; pump: EventPump }> }
   >();
+  private readonly ordinaryInflight = new Map<string, Promise<void>>();
+  private readonly ordinaryReplay = new Map<string, { session: Session; expiresAt: number }>();
 
-  constructor(private readonly deps: CoordinatorDeps) {}
+  constructor(private readonly deps: CoordinatorDeps) {
+    this.deps.ordinaryJournal?.setOnExpire((record) => {
+      const session = this.findSessionByAgentId(record.agentId);
+      if (session) this.deps.registry.forget(session, "ordinary_turn_expired");
+    });
+  }
 
   async handleMessages(
     req: IncomingMessage,
@@ -96,9 +117,24 @@ export class RunCoordinator {
     writerFactory: TurnWriterFactory = createAnthropicWriter,
   ): Promise<void> {
     this.deps.registry.sweep();
+    this.deps.ordinaryJournal?.sweepExpired();
     if (parsed.continuation) {
       await this.continueTurn(req, res, auth, parsed, parsed.continuation, requestId, writerFactory);
       return;
+    }
+    const turn = cursorAgentTurnFromParsed(parsed, { tenantScope: auth.fingerprint });
+    if (this.deps.config.ordinaryTurnCoordinator && this.deps.ordinaryJournal) {
+      const handled = await this.handleOrdinaryTurn(
+        req,
+        res,
+        auth,
+        parsed,
+        turn,
+        requestId,
+        writerFactory,
+        sessionHint,
+      );
+      if (handled) return;
     }
     if (sessionHint) {
       const existing = this.deps.registry.get(sessionHint);
@@ -109,7 +145,367 @@ export class RunCoordinator {
       await this.resumeCompletedLineage(req, res, auth, parsed, sessionHint, requestId, writerFactory);
       return;
     }
-    await this.startTurn(req, res, auth, parsed, requestId, writerFactory);
+    await this.startTurn(
+      req,
+      res,
+      auth,
+      parsed,
+      requestId,
+      writerFactory,
+      this.deps.config.ordinaryTurnCoordinator ? turn : undefined,
+    );
+  }
+
+  private async handleOrdinaryTurn(
+    req: IncomingMessage,
+    res: ServerResponse,
+    auth: AuthContext,
+    parsed: ParsedMessages,
+    turn: CursorAgentTurn,
+    requestId: string,
+    writerFactory: TurnWriterFactory,
+    sessionHint?: string,
+  ): Promise<boolean> {
+    const journal = this.deps.ordinaryJournal;
+    if (!journal) return false;
+    const key = ordinaryReplayKey(turn);
+    const inflight = this.ordinaryInflight.get(key);
+    if (inflight) {
+      await inflight;
+      const cached = this.ordinaryReplay.get(key);
+      if (!cached?.session.replay) {
+        throw sessionLost("completed Cursor ordinary turn cannot be replayed without its in-memory response");
+      }
+      this.writeReplay(res, cached.session, parsed.stream, requestId, writerFactory);
+      return true;
+    }
+
+    const decision = decideOrdinaryTurn({
+      turn,
+      journal,
+      inflight: new Set(this.ordinaryInflight.keys()),
+      now: this.deps.clock.now(),
+      enabled: true,
+      hasReplay: this.ordinaryReplay.has(key),
+    });
+
+    if (decision.action === "tool_continuation") return false;
+    if (decision.action === "replay") {
+      const cached = this.ordinaryReplay.get(key);
+      if (!cached?.session.replay) {
+        throw sessionLost("completed Cursor ordinary turn cannot be replayed without its in-memory response");
+      }
+      this.writeReplay(res, cached.session, parsed.stream, requestId, writerFactory);
+      return true;
+    }
+    if (decision.action === "fail_closed") {
+      throw sessionLost("completed Cursor ordinary turn cannot be replayed without its in-memory response");
+    }
+    if (decision.action === "singleflight") {
+      const pending = this.ordinaryInflight.get(key);
+      if (pending) {
+        await pending;
+        const cached = this.ordinaryReplay.get(key);
+        if (!cached?.session.replay) {
+          throw sessionLost("completed Cursor ordinary turn cannot be replayed without its in-memory response");
+        }
+        this.writeReplay(res, cached.session, parsed.stream, requestId, writerFactory);
+        return true;
+      }
+    }
+    if (decision.action === "rebuild" && sessionHint) {
+      return false;
+    }
+
+    if (decision.action === "resume") {
+      await this.claimOrdinaryTurn(req, res, auth, parsed, turn, requestId, writerFactory, {
+        mode: "resume",
+        parent: decision.record,
+      });
+      return true;
+    }
+
+    await this.claimOrdinaryTurn(req, res, auth, parsed, turn, requestId, writerFactory, {
+      mode: "rebuild",
+      reason: decision.action === "rebuild" ? decision.reason : "unknown_or_first",
+    });
+    return true;
+  }
+
+  private async claimOrdinaryTurn(
+    req: IncomingMessage,
+    res: ServerResponse,
+    auth: AuthContext,
+    parsed: ParsedMessages,
+    turn: CursorAgentTurn,
+    requestId: string,
+    writerFactory: TurnWriterFactory,
+    claim: { mode: "resume"; parent: OrdinaryTurnRecord } | { mode: "rebuild"; reason: string },
+  ): Promise<void> {
+    const journal = this.deps.ordinaryJournal;
+    if (!journal) {
+      await this.startTurn(req, res, auth, parsed, requestId, writerFactory, turn);
+      return;
+    }
+    const lineageKey = cursorAgentTurnLineageKey(turn);
+    const key = ordinaryReplayKey(turn);
+    const existing = this.ordinaryInflight.get(key);
+    if (existing) {
+      await existing;
+      const cached = this.ordinaryReplay.get(key);
+      if (!cached?.session.replay) {
+        throw sessionLost("completed Cursor ordinary turn cannot be replayed without its in-memory response");
+      }
+      this.writeReplay(res, cached.session, parsed.stream, requestId, writerFactory);
+      return;
+    }
+
+    let resolveInflight!: () => void;
+    let rejectInflight!: (error: unknown) => void;
+    const promise = new Promise<void>((resolve, reject) => {
+      resolveInflight = resolve;
+      rejectInflight = reject;
+    });
+    this.ordinaryInflight.set(key, promise);
+    void promise.catch(() => undefined);
+
+    const claimedAt = this.deps.clock.now();
+    const runningRecord: OrdinaryTurnRecord = {
+      lineageKey,
+      requestDigest: turn.lineage.requestDigest,
+      nextLineageKey: "",
+      tenantScope: turn.tenantScope,
+      route: turn.route,
+      channelId: turn.channelId,
+      effectiveModel: turn.effectiveModel,
+      parentAssistantAnchor: turn.lineage.parentAssistantAnchor,
+      turnIndex: turn.lineage.turnIndex,
+      toolCatalogDigest: turn.lineage.toolCatalogDigest,
+      assistantAnchor: "",
+      agentId: claim.mode === "resume" ? claim.parent.agentId : "",
+      credentialFingerprint: auth.fingerprint,
+      state: "running",
+      createdAt: claimedAt,
+      updatedAt: claimedAt,
+      expiresAt: claimedAt + this.deps.config.sessionTtlMs,
+    };
+    journal.upsert(runningRecord);
+
+    try {
+      await this.executeOrdinaryClaim(
+        req,
+        res,
+        auth,
+        parsed,
+        turn,
+        requestId,
+        writerFactory,
+        claim,
+      );
+      resolveInflight();
+    } catch (error) {
+      journal.remove(lineageKey, turn.lineage.requestDigest);
+      rejectInflight(error);
+      throw error;
+    } finally {
+      this.ordinaryInflight.delete(key);
+    }
+  }
+
+  private async executeOrdinaryClaim(
+    req: IncomingMessage,
+    res: ServerResponse,
+    auth: AuthContext,
+    parsed: ParsedMessages,
+    turn: CursorAgentTurn,
+    requestId: string,
+    writerFactory: TurnWriterFactory,
+    claim: { mode: "resume"; parent: OrdinaryTurnRecord } | { mode: "rebuild"; reason: string },
+  ): Promise<void> {
+    let resume = claim.mode === "resume";
+    if (resume && claim.mode === "resume") {
+      const live = this.findSessionByAgentId(claim.parent.agentId);
+      if (
+        live?.agent &&
+        live.state === "completed" &&
+        live.credentialFingerprint === auth.fingerprint &&
+        live.modelId === parsed.model &&
+        claim.parent.credentialFingerprint === auth.fingerprint
+      ) {
+        live.ordinaryTurn = turn;
+        this.traceOrdinary({
+          action: "resume",
+          reason: "exact_successor_live",
+          model: parsed.model,
+          send_chars: currentTurnSendPayload(turn).text.length,
+        });
+        await this.followUp(
+          req,
+          res,
+          auth,
+          parsed,
+          live,
+          requestId,
+          writerFactory,
+          currentTurnSendPayload(turn),
+        );
+        return;
+      }
+      if (live?.agent && live.credentialFingerprint !== auth.fingerprint) {
+        resume = false;
+      } else if (
+        claim.parent.agentId &&
+        claim.parent.credentialFingerprint === auth.fingerprint
+      ) {
+        await this.resumeOrdinaryAgent(
+          req,
+          res,
+          auth,
+          parsed,
+          turn,
+          claim.parent,
+          requestId,
+          writerFactory,
+        );
+        return;
+      } else {
+        resume = false;
+      }
+    }
+
+    const rebuildReason = claim.mode === "rebuild" ? claim.reason : "resume_fallback";
+    this.traceOrdinary({
+      action: "rebuild",
+      reason: rebuildReason,
+      model: parsed.model,
+      send_chars: renderPrompt(parsed).text.length,
+    });
+    await this.startTurn(req, res, auth, parsed, requestId, writerFactory, turn);
+  }
+
+  private async resumeOrdinaryAgent(
+    req: IncomingMessage,
+    res: ServerResponse,
+    auth: AuthContext,
+    parsed: ParsedMessages,
+    turn: CursorAgentTurn,
+    parent: OrdinaryTurnRecord,
+    requestId: string,
+    writerFactory: TurnWriterFactory,
+  ): Promise<void> {
+    this.deps.registry.assertCanActivateRun({
+      credentialFingerprint: auth.fingerprint,
+    });
+    const session = this.deps.registry.create({
+      credentialFingerprint: auth.fingerprint,
+      modelId: parsed.model,
+      modelParams: parsed.modelParams,
+    });
+    session.ordinaryTurn = turn;
+    try {
+      const customTools = mapClientTools(parsed.tools, session, this.deps.clock, () => undefined);
+      const agent = await this.deps.sdk.resumeAgent({
+        agentId: parent.agentId,
+        apiKey: auth.cursorApiKey,
+        modelId: parsed.model,
+        modelParams: session.modelParams,
+        workspaceDir: this.deps.workspaceDir,
+        clientToolNames: parsed.tools.map((tool) => tool.name),
+        customTools,
+      });
+      session.agent = agent;
+      session.sdkAgentId = parent.agentId;
+      this.traceOrdinary({
+        action: "resume",
+        reason: "exact_successor_store",
+        model: parsed.model,
+        send_chars: currentTurnSendPayload(turn).text.length,
+      });
+      await this.followUp(
+        req,
+        res,
+        auth,
+        parsed,
+        session,
+        requestId,
+        writerFactory,
+        currentTurnSendPayload(turn),
+      );
+    } catch (error) {
+      if (!res.headersSent) this.deps.registry.forget(session, "ordinary_resume_failed");
+      throw sdkFailure(error);
+    }
+  }
+
+  private traceOrdinary(event: {
+    action: "resume" | "rebuild";
+    reason: string;
+    model: string;
+    send_chars: number;
+  }): void {
+    this.deps.logger.info(
+      {
+        model: event.model,
+        action: event.action,
+        reason: event.reason,
+        send_chars: event.send_chars,
+      },
+      "ordinary turn",
+    );
+    try {
+      appendFileSync(
+        join(this.deps.config.stateDir, "ordinary-trace.jsonl"),
+        `${JSON.stringify({ t: this.deps.clock.now(), ...event })}\n`,
+        { encoding: "utf8", mode: 0o600 },
+      );
+    } catch {
+      // diagnostic only
+    }
+  }
+
+  private findSessionByAgentId(agentId: string): Session | undefined {
+    if (!agentId) return undefined;
+    for (const session of this.deps.registry.sessions.values()) {
+      if (session.sdkAgentId === agentId || session.agent?.agentId === agentId) return session;
+    }
+    return undefined;
+  }
+
+  private rememberOrdinaryCompletion(session: Session): void {
+    const turn = session.ordinaryTurn;
+    const journal = this.deps.ordinaryJournal;
+    if (!turn || !journal || !session.replay) return;
+    if (session.state !== "completed" && session.state !== "awaiting_tool_results") return;
+    const assistantAnchor = digestAssistantAnchor(session.replay.turn.blocks);
+    const now = this.deps.clock.now();
+    const completed: OrdinaryTurnRecord = {
+      lineageKey: cursorAgentTurnLineageKey(turn),
+      requestDigest: turn.lineage.requestDigest,
+      nextLineageKey: nextCursorAgentTurnLineageKey(turn, assistantAnchor),
+      tenantScope: turn.tenantScope,
+      route: turn.route,
+      channelId: turn.channelId,
+      effectiveModel: turn.effectiveModel,
+      parentAssistantAnchor: turn.lineage.parentAssistantAnchor,
+      turnIndex: turn.lineage.turnIndex,
+      toolCatalogDigest: turn.lineage.toolCatalogDigest,
+      assistantAnchor,
+      agentId: session.sdkAgentId ?? session.agent?.agentId ?? "",
+      credentialFingerprint: session.credentialFingerprint,
+      state: "completed",
+      createdAt: session.createdAt,
+      updatedAt: now,
+      expiresAt: now + this.deps.config.sessionTtlMs,
+    };
+    journal.upsert(completed);
+    this.ordinaryReplay.set(ordinaryReplayKey(turn), {
+      session,
+      expiresAt: completed.expiresAt,
+    });
+    if (session.state === "completed") {
+      session.retainOrdinaryAgent = true;
+      session.retainUntil = completed.expiresAt;
+    }
   }
 
   private async startTurn(
@@ -119,12 +515,15 @@ export class RunCoordinator {
     parsed: ParsedMessages,
     requestId: string,
     writerFactory: TurnWriterFactory,
+    ordinaryTurn?: CursorAgentTurn,
+    sendOverride?: { text: string; images: Array<{ data: string; mimeType: string }> },
   ): Promise<void> {
     const session = this.deps.registry.create({
       credentialFingerprint: auth.fingerprint,
       modelId: parsed.model,
       modelParams: parsed.modelParams,
     });
+    if (ordinaryTurn) session.ordinaryTurn = ordinaryTurn;
     const customTools = mapClientTools(parsed.tools, session, this.deps.clock, () => undefined);
     try {
       const agent = await this.deps.sdk.createAgent({
@@ -138,7 +537,7 @@ export class RunCoordinator {
       session.agent = agent;
       session.sdkAgentId = agent.agentId;
       session.state = "running";
-      const prompt = renderPrompt(parsed);
+      const prompt = sendOverride ?? renderPrompt(parsed);
       const deltas = createDeltaBridge();
       const run = await agent.send({
         text: prompt.text,
@@ -174,6 +573,7 @@ export class RunCoordinator {
     session: Session,
     requestId: string,
     writerFactory: TurnWriterFactory,
+    sendOverride?: { text: string; images: Array<{ data: string; mimeType: string }> },
   ): Promise<void> {
     this.assertIdentity(session, auth, parsed.model, parsed.modelParams);
     if (!session.agent) {
@@ -196,7 +596,7 @@ export class RunCoordinator {
     session.replay = undefined;
     session.appliedBoundaryId = undefined;
     const customTools = mapClientTools(parsed.tools, session, this.deps.clock, () => undefined);
-    const prompt = renderPrompt(parsed);
+    const prompt = sendOverride ?? renderPrompt(parsed);
     const deltas = createDeltaBridge();
     try {
       const run = await session.agent.send({
@@ -607,6 +1007,7 @@ export class RunCoordinator {
           for (const call of session.pending.values()) {
             this.deps.registry.indexTool(call.toolUseId, session.sessionId);
           }
+          this.rememberOrdinaryCompletion(session);
           this.deps.logger.info(
             {
               session_id: session.sessionId,
@@ -618,6 +1019,7 @@ export class RunCoordinator {
         } else {
           session.state = "completed";
           session.touch(this.deps.clock);
+          this.rememberOrdinaryCompletion(session);
           this.deps.logger.info(
             {
               session_id: session.sessionId,

--- a/src/core/session-registry.ts
+++ b/src/core/session-registry.ts
@@ -155,6 +155,9 @@ export class SessionRegistry {
         session.replay &&
         now - session.replay.createdAt > this.limits.replayTtlMs
       ) {
+        if (session.retainOrdinaryAgent && now < session.retainUntil) {
+          continue;
+        }
         this.forget(session, "replay_ttl");
       }
     }

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -2,6 +2,7 @@ import { sessionId, toolUseId } from "../ids.js";
 import type { Clock } from "../clock.js";
 import type { SdkAgent, SdkCustomToolResult, SdkRun } from "../sdk/port.js";
 import type { AssistantTurn } from "../protocols/anthropic/types.js";
+import type { CursorAgentTurn } from "./cursor-agent-turn.js";
 import type { EventPump } from "./event-pump.js";
 
 export type SessionState =
@@ -56,6 +57,9 @@ export class Session {
   lastResultDigest?: string;
   appliedBoundaryId?: string;
   closeReason?: string;
+  ordinaryTurn?: CursorAgentTurn;
+  retainOrdinaryAgent = false;
+  retainUntil = 0;
 
   constructor(input: {
     credentialFingerprint: string;

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1,4 +1,5 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { join } from "node:path";
 import { CursorAccountPool } from "../auth/account-pool.js";
 import {
   authorizeClient,
@@ -13,6 +14,7 @@ import type { GatewayConfig } from "../config.js";
 import { RunCoordinator } from "../core/run-coordinator.js";
 import type { PumpBoundary } from "../core/event-pump.js";
 import { LineageStore } from "../core/lineage-store.js";
+import { OrdinaryTurnJournal } from "../core/ordinary-turn-journal.js";
 import { SessionRegistry } from "../core/session-registry.js";
 import {
   forbiddenError,
@@ -48,6 +50,7 @@ export interface App {
   coordinator: RunCoordinator;
   catalog: ModelCatalog;
   lineage: LineageStore;
+  ordinaryJournal: OrdinaryTurnJournal;
   accounts: CursorAccountFileStore;
   sdk: SdkRuntime;
   handler: (req: IncomingMessage, res: ServerResponse) => Promise<void>;
@@ -132,6 +135,9 @@ export function createApp(input: {
     runDeadlineMs: config.runDeadlineMs,
   });
   const lineage = new LineageStore(config.stateDir, clock);
+  const ordinaryJournal = new OrdinaryTurnJournal(join(config.stateDir, "ordinary-turns.json"), {
+    now: () => clock.now(),
+  });
   const coordinator = new RunCoordinator({
     config,
     sdk,
@@ -140,6 +146,7 @@ export function createApp(input: {
     logger,
     workspaceDir,
     lineage,
+    ordinaryJournal,
     beforeApplyBoundary,
   });
   const catalog = new ModelCatalog(sdk, clock, config.catalogCacheMs);
@@ -292,6 +299,7 @@ export function createApp(input: {
     try {
       registry.sweep();
       lineage.sweep();
+      ordinaryJournal.sweepExpired();
     } catch {
       // sweep must not crash the process
     }
@@ -335,6 +343,7 @@ export function createApp(input: {
               ...config.capabilities,
               agent_resume: config.capabilities.agent_resume,
               pending_tool_restart_resume: config.capabilities.pending_tool_restart_resume,
+              ordinary_turn_coordinator: config.ordinaryTurnCoordinator,
               store_backend: config.capabilities.store_backend ?? "jsonl",
             },
             verification: {
@@ -605,6 +614,7 @@ export function createApp(input: {
     coordinator,
     catalog,
     lineage,
+    ordinaryJournal,
     accounts,
     sdk,
     handler,

--- a/tests/contract/cursor-agent-turn.test.ts
+++ b/tests/contract/cursor-agent-turn.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "vitest";
+import {
+  cursorAgentTurnFromParsed,
+  cursorAgentTurnLineageKey,
+  currentTurnSendPayload,
+  digestAssistantAnchor,
+  nextCursorAgentTurnLineageKey,
+} from "../../src/core/cursor-agent-turn.js";
+import { parseMessagesRequest } from "../../src/protocols/anthropic/parse.js";
+
+test("string and block assistant content share an anchor", () => {
+  expect(digestAssistantAnchor("hello world")).toBe(
+    digestAssistantAnchor([{ type: "text", text: "hello world" }]),
+  );
+});
+
+test("current-turn payload is only the latest user text", () => {
+  const parsed = parseMessagesRequest({
+    model: "grok-4.6",
+    reasoning_effort: "xhigh",
+    max_tokens: 16,
+    messages: [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "first" },
+      { role: "user", content: "next" },
+    ],
+  });
+  const turn = cursorAgentTurnFromParsed(parsed, { tenantScope: "a".repeat(64) });
+  expect(turn.lineage.turnIndex).toBe(2);
+  expect(turn.lineage.parentAssistantAnchor).toBe(digestAssistantAnchor("first"));
+  expect(currentTurnSendPayload(turn)).toEqual({ text: "next", images: [] });
+  expect(turn.effectiveModel).toContain("grok-4.6");
+  expect(turn.effectiveModel).toContain("xhigh");
+});
+
+test("next lineage key is the successor parent/turn index", () => {
+  const tenant = "b".repeat(64);
+  const first = cursorAgentTurnFromParsed(
+    parseMessagesRequest({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "hello" }],
+    }),
+    { tenantScope: tenant },
+  );
+  const anchor = digestAssistantAnchor("first");
+  const follow = cursorAgentTurnFromParsed(
+    parseMessagesRequest({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "first" },
+        { role: "user", content: "next" },
+      ],
+    }),
+    { tenantScope: tenant },
+  );
+  expect(cursorAgentTurnLineageKey(follow)).toBe(nextCursorAgentTurnLineageKey(first, anchor));
+});

--- a/tests/contract/ordinary-turn-decide.test.ts
+++ b/tests/contract/ordinary-turn-decide.test.ts
@@ -1,0 +1,143 @@
+import { expect, test } from "vitest";
+import {
+  cursorAgentTurnFromParsed,
+  cursorAgentTurnLineageKey,
+  digestAssistantAnchor,
+  nextCursorAgentTurnLineageKey,
+} from "../../src/core/cursor-agent-turn.js";
+import { decideOrdinaryTurn } from "../../src/core/ordinary-turn.js";
+import { OrdinaryTurnJournal } from "../../src/core/ordinary-turn-journal.js";
+import { parseMessagesRequest } from "../../src/protocols/anthropic/parse.js";
+
+const TENANT = "c".repeat(64);
+
+function turn(messages: Array<{ role: string; content: string }>, extras: { model?: string } = {}) {
+  return cursorAgentTurnFromParsed(
+    parseMessagesRequest({
+      model: extras.model ?? "composer-2.5",
+      max_tokens: 16,
+      messages,
+    }),
+    { tenantScope: TENANT },
+  );
+}
+
+function makeJournal() {
+  return new OrdinaryTurnJournal("", { now: () => 10 });
+}
+
+function completedRecord(first: ReturnType<typeof turn>, assistant = "first") {
+  const assistantAnchor = digestAssistantAnchor(assistant);
+  return {
+    lineageKey: cursorAgentTurnLineageKey(first),
+    requestDigest: first.lineage.requestDigest,
+    nextLineageKey: nextCursorAgentTurnLineageKey(first, assistantAnchor),
+    tenantScope: first.tenantScope,
+    route: first.route,
+    channelId: first.channelId,
+    effectiveModel: first.effectiveModel,
+    parentAssistantAnchor: first.lineage.parentAssistantAnchor,
+    turnIndex: first.lineage.turnIndex,
+    toolCatalogDigest: first.lineage.toolCatalogDigest,
+    assistantAnchor,
+    agentId: "agent-1",
+    credentialFingerprint: TENANT,
+    state: "completed" as const,
+    createdAt: 1,
+    updatedAt: 1,
+    expiresAt: 1_000_000,
+  };
+}
+
+test("unknown first turn rebuilds", () => {
+  const store = makeJournal();
+  const decision = decideOrdinaryTurn({
+    turn: turn([{ role: "user", content: "hello" }]),
+    journal: store,
+    inflight: new Set(),
+    now: 10,
+    enabled: true,
+    hasReplay: false,
+  });
+  expect(decision).toEqual({ action: "rebuild", reason: "unknown_or_first" });
+});
+
+test("exact successor resumes", () => {
+  const store = makeJournal();
+  const first = turn([{ role: "user", content: "hello" }]);
+  store.upsert(completedRecord(first));
+  const follow = turn([
+    { role: "user", content: "hello" },
+    { role: "assistant", content: "first" },
+    { role: "user", content: "next" },
+  ]);
+  const decision = decideOrdinaryTurn({
+    turn: follow,
+    journal: store,
+    inflight: new Set(),
+    now: 10,
+    enabled: true,
+    hasReplay: false,
+  });
+  expect(decision.action).toBe("resume");
+  expect(decision.reason).toBe("exact_successor");
+});
+
+test("forked successor rebuilds", () => {
+  const store = makeJournal();
+  const first = turn([{ role: "user", content: "hello" }]);
+  store.upsert(completedRecord(first));
+  const pathA = turn([
+    { role: "user", content: "hello" },
+    { role: "assistant", content: "first" },
+    { role: "user", content: "path-a" },
+  ]);
+  store.upsert({
+    ...completedRecord(first),
+    lineageKey: cursorAgentTurnLineageKey(pathA),
+    requestDigest: pathA.lineage.requestDigest,
+    parentAssistantAnchor: pathA.lineage.parentAssistantAnchor,
+    turnIndex: pathA.lineage.turnIndex,
+  });
+  const pathB = turn([
+    { role: "user", content: "hello" },
+    { role: "assistant", content: "first" },
+    { role: "user", content: "path-b" },
+  ]);
+  const decision = decideOrdinaryTurn({
+    turn: pathB,
+    journal: store,
+    inflight: new Set(),
+    now: 10,
+    enabled: true,
+    hasReplay: false,
+  });
+  expect(decision).toMatchObject({ action: "rebuild", reason: "fork" });
+});
+
+test("identical digest without in-memory replay fails closed", () => {
+  const store = makeJournal();
+  const first = turn([{ role: "user", content: "hello" }]);
+  store.upsert(completedRecord(first));
+  const decision = decideOrdinaryTurn({
+    turn: first,
+    journal: store,
+    inflight: new Set(),
+    now: 10,
+    enabled: true,
+    hasReplay: false,
+  });
+  expect(decision.action).toBe("fail_closed");
+});
+
+test("disabled coordinator always rebuilds", () => {
+  const decision = decideOrdinaryTurn({
+    turn: turn([{ role: "user", content: "hello" }]),
+    journal: new OrdinaryTurnJournal(),
+    inflight: new Set(),
+    now: 10,
+    enabled: false,
+    hasReplay: false,
+  });
+  expect(decision).toEqual({ action: "rebuild", reason: "coordinator_disabled" });
+});

--- a/tests/integration/capacity.test.ts
+++ b/tests/integration/capacity.test.ts
@@ -32,11 +32,14 @@ function textBody(content: string, extra: Record<string, unknown> = {}) {
   });
 }
 
+let sessionSeq = 0;
+
 async function completeSession(ctx: TestContext, apiKey = "test-key-a"): Promise<string> {
+  sessionSeq += 1;
   const res = await api(ctx, "/v1/messages", {
     apiKey,
     method: "POST",
-    body: textBody("hi"),
+    body: textBody(`hi-${sessionSeq}`),
   });
   expect(res.status).toBe(200);
   return ((await res.json()) as { cursor_session_id: string }).cursor_session_id;

--- a/tests/integration/ordinary-turn-coordinator.test.ts
+++ b/tests/integration/ordinary-turn-coordinator.test.ts
@@ -1,0 +1,284 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test } from "vitest";
+import { api, closeTestApp, startTestApp, type TestContext } from "../helpers/app.js";
+
+let ctx: TestContext;
+
+afterEach(async () => {
+  if (ctx) await closeTestApp(ctx);
+});
+
+function followBody(assistant: string, next = "next", extras: Record<string, unknown> = {}) {
+  return {
+    model: "composer-2.5",
+    max_tokens: 16,
+    messages: [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: assistant },
+      { role: "user", content: next },
+    ],
+    ...extras,
+  };
+}
+
+test("exact ordinary next turn reuses one Agent and sends only current text", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      scripts: [[{ type: "text", chunks: ["first"] }], [{ type: "text", chunks: ["second"] }]],
+    },
+  });
+  const first = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "hello" }],
+    }),
+  });
+  const firstBody = (await first.json()) as { content: Array<{ text?: string }> };
+  expect(first.status).toBe(200);
+  expect(ctx.sdk.createCalls).toHaveLength(1);
+
+  const follow = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify(followBody(firstBody.content[0]?.text ?? "first")),
+  });
+  expect(follow.status).toBe(200);
+  expect(ctx.sdk.createCalls).toHaveLength(1);
+  expect(ctx.sdk.resumeCalls).toHaveLength(0);
+  expect(ctx.sdk.agents[0]?.runs).toHaveLength(2);
+  expect(ctx.sdk.agents[0]?.lastSend?.text).toBe("next");
+  expect(ctx.sdk.agents[0]?.lastSend?.text).not.toContain("hello");
+});
+
+test("feature flag off keeps a cold rebuild for every ordinary turn", async () => {
+  ctx = await startTestApp({
+    config: { ordinaryTurnCoordinator: false },
+    sdk: {
+      scripts: [[{ type: "text", chunks: ["first"] }], [{ type: "text", chunks: ["second"] }]],
+    },
+  });
+  const first = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "hello" }],
+    }),
+  });
+  const firstBody = (await first.json()) as { content: Array<{ text?: string }> };
+  await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify(followBody(firstBody.content[0]?.text ?? "first")),
+  });
+  expect(ctx.sdk.createCalls).toHaveLength(2);
+  expect(ctx.sdk.agents[1]?.lastSend?.text).toContain("hello");
+  expect(ctx.sdk.agents[1]?.lastSend?.text).toContain("next");
+});
+
+test("identical request digest replays without a second SDK send", async () => {
+  ctx = await startTestApp({
+    sdk: { scripts: [[{ type: "text", chunks: ["same"] }]] },
+  });
+  const payload = {
+    model: "composer-2.5",
+    max_tokens: 16,
+    messages: [{ role: "user", content: "hello" }],
+  };
+  const [a, b] = await Promise.all([
+    api(ctx, "/v1/messages", { method: "POST", body: JSON.stringify(payload) }),
+    api(ctx, "/v1/messages", { method: "POST", body: JSON.stringify(payload) }),
+  ]);
+  expect(a.status).toBe(200);
+  expect(b.status).toBe(200);
+  expect(ctx.sdk.createCalls).toHaveLength(1);
+  const later = await api(ctx, "/v1/messages", { method: "POST", body: JSON.stringify(payload) });
+  expect(later.status).toBe(200);
+  expect(ctx.sdk.createCalls).toHaveLength(1);
+  expect(((await a.json()) as { content: unknown }).content).toEqual(
+    ((await later.json()) as { content: unknown }).content,
+  );
+});
+
+test("a forked successor cold-rebuilds without sending on the original Agent", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      agentScripts: [
+        [[{ type: "text", chunks: ["first"] }], [{ type: "text", chunks: ["path-a"] }]],
+        [[{ type: "text", chunks: ["path-b"] }]],
+      ],
+    },
+  });
+  const first = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "hello" }],
+    }),
+  });
+  const assistant = ((await first.json()) as { content: Array<{ text?: string }> }).content[0]?.text ?? "first";
+  const original = ctx.sdk.agents[0];
+  const branchA = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify(followBody(assistant, "path-a")),
+  });
+  const branchB = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify(followBody(assistant, "path-b")),
+  });
+  expect(branchA.status).toBe(200);
+  expect(branchB.status).toBe(200);
+  expect(ctx.sdk.createCalls).toHaveLength(2);
+  expect(original?.runs).toHaveLength(2);
+  expect(original?.lastSend?.text).toBe("path-a");
+  expect(ctx.sdk.agents[1]?.lastSend?.text).toContain("path-b");
+  expect(ctx.sdk.agents[1]?.lastSend?.text).toContain("hello");
+});
+
+test("model or tool catalog mismatch never attaches", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      scripts: [[{ type: "text", chunks: ["first"] }], [{ type: "text", chunks: ["other"] }]],
+    },
+  });
+  const first = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "hello" }],
+    }),
+  });
+  const assistant = ((await first.json()) as { content: Array<{ text?: string }> }).content[0]?.text ?? "first";
+  const otherModel = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify({
+      ...followBody(assistant),
+      model: "grok-4.6",
+    }),
+  });
+  expect(otherModel.status).toBe(200);
+  expect(ctx.sdk.createCalls).toHaveLength(2);
+});
+
+test("credential rotation never resumes the original Agent", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      scripts: [[{ type: "text", chunks: ["first"] }], [{ type: "text", chunks: ["rotated"] }]],
+    },
+  });
+  const first = await api(ctx, "/v1/messages", {
+    method: "POST",
+    apiKey: "test-key-a",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "hello" }],
+    }),
+  });
+  const assistant = ((await first.json()) as { content: Array<{ text?: string }> }).content[0]?.text ?? "first";
+  const follow = await api(ctx, "/v1/messages", {
+    method: "POST",
+    apiKey: "test-key-b",
+    body: JSON.stringify(followBody(assistant)),
+  });
+  expect(follow.status).toBe(200);
+  expect(ctx.sdk.createCalls).toHaveLength(2);
+  expect(ctx.sdk.agents[1]?.lastSend?.text).toContain("hello");
+});
+
+test("x-cursor-session-id follow-up still reuses the Agent", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      scripts: [[{ type: "text", chunks: ["first"] }], [{ type: "text", chunks: ["second"] }]],
+    },
+  });
+  const first = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "hello" }],
+    }),
+  });
+  const sessionId = ((await first.json()) as { cursor_session_id: string }).cursor_session_id;
+  const follow = await api(ctx, "/v1/messages", {
+    method: "POST",
+    headers: { "x-cursor-session-id": sessionId },
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "again" }],
+    }),
+  });
+  expect(follow.status).toBe(200);
+  expect(follow.headers.get("x-cursor-session-id")).toBe(sessionId);
+  expect(ctx.sdk.createCalls).toHaveLength(1);
+  expect(ctx.sdk.agents[0]?.runs).toHaveLength(2);
+});
+
+test("process restart resumes the persisted Agent and sends only the current turn", async () => {
+  const stateDir = mkdtempSync(join(tmpdir(), "cursor-sdk2api-ordinary-"));
+  const firstApp = await startTestApp({
+    config: { stateDir },
+    sdk: { scripts: [[{ type: "text", chunks: ["first"] }]] },
+  });
+  const first = await api(firstApp, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "hello" }],
+    }),
+  });
+  const assistant = ((await first.json()) as { content: Array<{ text?: string }> }).content[0]?.text ?? "first";
+  const agentId = firstApp.sdk.agents[0]?.agentId;
+  await closeTestApp(firstApp);
+
+  ctx = await startTestApp({
+    config: { stateDir },
+    sdk: { scripts: [[{ type: "text", chunks: ["second"] }]] },
+  });
+  const follow = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify(followBody(assistant)),
+  });
+  expect(follow.status).toBe(200);
+  expect(ctx.sdk.createCalls).toHaveLength(0);
+  expect(ctx.sdk.resumeCalls).toHaveLength(1);
+  expect(ctx.sdk.lastResume?.agentId).toBe(agentId);
+  expect(ctx.sdk.agents[0]?.lastSend?.text).toBe("next");
+});
+
+test("Responses exact successor sends only the current turn", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      scripts: [[{ type: "text", chunks: ["first"] }], [{ type: "text", chunks: ["second"] }]],
+    },
+  });
+  const first = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: "hello",
+    }),
+  });
+  expect(first.status).toBe(200);
+  const follow = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] },
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "first" }] },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "next" }] },
+      ],
+    }),
+  });
+  expect(follow.status).toBe(200);
+  expect(ctx.sdk.createCalls).toHaveLength(1);
+  expect(ctx.sdk.agents[0]?.lastSend?.text).toBe("next");
+});

--- a/tests/live-smoke/README.md
+++ b/tests/live-smoke/README.md
@@ -11,6 +11,7 @@ npm run build
 export CURSOR_LIVE_SMOKE=1
 export CURSOR_API_KEY=...   # do not commit; do not paste into chat
 npm run live:smoke
+npm run live:ordinary   # exact-lineage ordinary follow-up only
 ```
 
 Optional:

--- a/tests/live-smoke/ordinary-turn-live.ts
+++ b/tests/live-smoke/ordinary-turn-live.ts
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { gatewayGet, postMessages, type GatewayResponse } from "./lib/client.js";
+import { liveSmokeGate } from "./lib/gate.js";
+import { redactSecrets } from "./lib/redact.js";
+import { startChildGateway, type ChildGateway } from "./lib/spawn.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..", "..");
+
+interface TraceEvent {
+  action?: string;
+  reason?: string;
+  send_chars?: number;
+  model?: string;
+}
+
+interface JournalRecord {
+  agentId?: string;
+  turnIndex?: number;
+  state?: string;
+  effectiveModel?: string;
+}
+
+interface CaseRecord {
+  id: string;
+  status: "pass" | "fail" | "skip" | "catalog_missing";
+  required?: boolean;
+  http_status?: number;
+  error_type?: string;
+  duration_ms?: number;
+  first_event_ms?: number;
+  usage?: Record<string, number>;
+  counts?: Record<string, number>;
+  reason?: string;
+}
+
+function assistantContent(raw: unknown): unknown {
+  if (!raw || typeof raw !== "object") return "";
+  return (raw as { content?: unknown }).content ?? "";
+}
+
+function readTrace(stateDir: string): TraceEvent[] {
+  const path = join(stateDir, "ordinary-trace.jsonl");
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as TraceEvent);
+}
+
+function readJournal(stateDir: string): JournalRecord[] {
+  const path = join(stateDir, "ordinary-turns.json");
+  if (!existsSync(path)) return [];
+  const parsed = JSON.parse(readFileSync(path, "utf8")) as { records?: JournalRecord[] };
+  return Array.isArray(parsed.records) ? parsed.records : [];
+}
+
+function modelExtras(model: string): Record<string, unknown> {
+  return model === "grok-4.6" ? { reasoning_effort: "medium" } : {};
+}
+
+function tracesFor(stateDir: string, model: string): TraceEvent[] {
+  return readTrace(stateDir).filter((item) => item.model === model);
+}
+
+function lastAction(stateDir: string, model: string, action: "resume" | "rebuild"): TraceEvent | undefined {
+  return tracesFor(stateDir, model).filter((item) => item.action === action).at(-1);
+}
+
+function currentTurnOk(sendChars: number, userText: string): boolean {
+  return sendChars > 0 && sendChars <= userText.length + 8;
+}
+
+async function main(): Promise<void> {
+  const gate = liveSmokeGate(process.env);
+  if (!gate.ok) {
+    console.error(gate.message);
+    process.exit(gate.code);
+  }
+  const apiKey = process.env.CURSOR_API_KEY?.trim() ?? "";
+  const canaries = [apiKey];
+  const timeoutMs = Number.parseInt(process.env.LIVE_SMOKE_TIMEOUT_MS ?? "180000", 10);
+  const models = (process.env.LIVE_SMOKE_MODELS?.trim() || "grok-4.6,composer-2.5,claude-sonnet-4-6")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  const output =
+    process.env.LIVE_SMOKE_OUTPUT?.trim() ||
+    join(tmpdir(), `cursor-sdk2api-ordinary-live-${Date.now()}.json`);
+  const distEntry = join(repoRoot, "dist", "index.js");
+  if (!existsSync(distEntry)) {
+    console.error("dist/index.js is missing. Run npm run build before live:ordinary.");
+    process.exit(3);
+  }
+
+  const child = await startChildGateway({ repoRoot, distEntry, canaries });
+  const cases: CaseRecord[] = [];
+  let exitCode = 1;
+  try {
+    const health = await fetch(`${child.baseUrl}/health`, { signal: AbortSignal.timeout(5000) });
+    const healthJson = (await health.json()) as {
+      sdk_version?: string;
+      capabilities?: { ordinary_turn_coordinator?: boolean };
+    };
+    if (healthJson.capabilities?.ordinary_turn_coordinator !== true) {
+      throw new Error("ordinary_turn_coordinator is not enabled on /health");
+    }
+    const catalog = await gatewayGet(child.baseUrl, "/v1/models", apiKey, timeoutMs);
+    const catalogIds = Array.isArray((catalog.json as { data?: Array<{ id?: string }> }).data)
+      ? ((catalog.json as { data: Array<{ id?: string }> }).data.map((item) => item.id).filter(Boolean) as string[])
+      : [];
+    cases.push({
+      id: "catalog",
+      status: catalog.status === 200 && catalogIds.length > 0 ? "pass" : "fail",
+      http_status: catalog.status,
+      counts: { models: catalogIds.length },
+    });
+
+    for (const model of models) {
+      if (!catalogIds.includes(model)) {
+        cases.push({ id: `${model}/ordinary_successor`, status: "catalog_missing", required: false });
+        continue;
+      }
+      cases.push(...(await runConversation(child, apiKey, timeoutMs, model)));
+    }
+    if (catalogIds.includes("grok-4.6")) {
+      cases.push(await runPadded(child, apiKey, timeoutMs));
+    }
+
+    const receipt = {
+      schema: "cursor-sdk2api.ordinary-live.v2",
+      ok: cases.every((item) => item.status === "pass" || item.status === "skip" || item.status === "catalog_missing"),
+      sdk_version: healthJson.sdk_version,
+      ordinary_turn_coordinator: true,
+      cases,
+    };
+    mkdirSync(dirname(output), { recursive: true });
+    writeFileSync(output, `${JSON.stringify(receipt, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+    for (const item of cases) {
+      console.log(
+        `case ${item.id} ${item.status}${item.duration_ms ? ` ${item.duration_ms}ms` : ""}${
+          item.reason ? ` ${item.reason}` : ""
+        }`,
+      );
+    }
+    console.log(`receipt ${output}`);
+    console.log(`ok=${receipt.ok}`);
+    exitCode = receipt.ok && cases.some((item) => item.status === "pass" && item.id !== "catalog") ? 0 : 1;
+  } catch (error) {
+    console.error(redactSecrets(error instanceof Error ? error.message : "ordinary live failed", canaries));
+    exitCode = 1;
+  } finally {
+    await child.stop().catch(() => undefined);
+    child.cleanup();
+  }
+  process.exit(exitCode);
+}
+
+async function postTurn(
+  child: ChildGateway,
+  apiKey: string,
+  timeoutMs: number,
+  model: string,
+  messages: unknown[],
+): Promise<GatewayResponse> {
+  return postMessages({
+    baseUrl: child.baseUrl,
+    apiKey,
+    timeoutMs,
+    body: {
+      model,
+      max_tokens: 64,
+      ...modelExtras(model),
+      messages,
+    },
+  });
+}
+
+function fail(id: string, res: GatewayResponse, reason: string, started: number): CaseRecord {
+  return {
+    id,
+    status: "fail",
+    http_status: res.status,
+    error_type: res.error_type,
+    duration_ms: Date.now() - started,
+    reason: res.reason_class ?? res.error_type ?? reason,
+  };
+}
+
+async function runConversation(
+  child: ChildGateway,
+  apiKey: string,
+  timeoutMs: number,
+  model: string,
+): Promise<CaseRecord[]> {
+  const users = [
+    "Reply with the single word PONG and nothing else.",
+    "Reply with the single word PING and nothing else.",
+    "Reply with the single word OKAY and nothing else.",
+    "Reply with the single word DONE and nothing else.",
+  ];
+  const started = Date.now();
+  const first = await postTurn(child, apiKey, timeoutMs, model, [{ role: "user", content: users[0] }]);
+  if (first.status !== 200 || first.error_type) {
+    return [fail(`${model}/ordinary_successor`, first, "first_turn_failed", started)];
+  }
+
+  const second = await postTurn(child, apiKey, timeoutMs, model, [
+    { role: "user", content: users[0] },
+    { role: "assistant", content: assistantContent(first.raw) },
+    { role: "user", content: users[1] },
+  ]);
+  const secondResume = lastAction(child.stateDir, model, "resume");
+  const firstRebuild = tracesFor(child.stateDir, model).find((item) => item.action === "rebuild");
+  const successorOk =
+    second.status === 200 &&
+    !second.error_type &&
+    secondResume?.reason === "exact_successor_live" &&
+    currentTurnOk(secondResume.send_chars ?? 0, users[1] ?? "") &&
+    (firstRebuild?.send_chars ?? 0) > (secondResume.send_chars ?? 0);
+  const cases: CaseRecord[] = [
+    {
+      id: `${model}/ordinary_successor`,
+      status: successorOk ? "pass" : "fail",
+      http_status: second.status,
+      error_type: second.error_type,
+      duration_ms: Date.now() - started,
+      usage: second.usage,
+      counts: {
+        first_send_chars: firstRebuild?.send_chars ?? 0,
+        second_send_chars: secondResume?.send_chars ?? 0,
+        cache_read: second.usage?.cache_read_input_tokens ?? 0,
+      },
+      reason: successorOk ? undefined : "successor_not_incremental",
+    },
+  ];
+  if (!successorOk) return cases;
+
+  const thirdStarted = Date.now();
+  const third = await postTurn(child, apiKey, timeoutMs, model, [
+    { role: "user", content: users[0] },
+    { role: "assistant", content: assistantContent(first.raw) },
+    { role: "user", content: users[1] },
+    { role: "assistant", content: assistantContent(second.raw) },
+    { role: "user", content: users[2] },
+  ]);
+  const thirdResume = lastAction(child.stateDir, model, "resume");
+  const thirdOk =
+    third.status === 200 &&
+    !third.error_type &&
+    thirdResume?.reason === "exact_successor_live" &&
+    currentTurnOk(thirdResume.send_chars ?? 0, users[2] ?? "");
+  cases.push({
+    id: `${model}/ordinary_third`,
+    status: thirdOk ? "pass" : "fail",
+    http_status: third.status,
+    error_type: third.error_type,
+    duration_ms: Date.now() - thirdStarted,
+    usage: third.usage,
+    counts: {
+      third_send_chars: thirdResume?.send_chars ?? 0,
+      cache_read: third.usage?.cache_read_input_tokens ?? 0,
+    },
+    reason: thirdOk ? undefined : "third_turn_not_incremental",
+  });
+  if (!thirdOk) return cases;
+
+  const restartStarted = Date.now();
+  await child.restart();
+  const fourth = await postTurn(child, apiKey, timeoutMs, model, [
+    { role: "user", content: users[0] },
+    { role: "assistant", content: assistantContent(first.raw) },
+    { role: "user", content: users[1] },
+    { role: "assistant", content: assistantContent(second.raw) },
+    { role: "user", content: users[2] },
+    { role: "assistant", content: assistantContent(third.raw) },
+    { role: "user", content: users[3] },
+  ]);
+  const fourthResume = lastAction(child.stateDir, model, "resume");
+  const journal = readJournal(child.stateDir).filter(
+    (item) =>
+      item.state === "completed" &&
+      Number(item.turnIndex) > 0 &&
+      String(item.effectiveModel || "").startsWith(`${model}|`),
+  );
+  const agentIds = [...new Set(journal.map((item) => item.agentId).filter(Boolean))];
+  const restartOk =
+    fourth.status === 200 &&
+    !fourth.error_type &&
+    fourthResume?.reason === "exact_successor_store" &&
+    currentTurnOk(fourthResume.send_chars ?? 0, users[3] ?? "") &&
+    agentIds.length === 1;
+  cases.push({
+    id: `${model}/ordinary_restart`,
+    status: restartOk ? "pass" : "fail",
+    http_status: fourth.status,
+    error_type: fourth.error_type,
+    duration_ms: Date.now() - restartStarted,
+    usage: fourth.usage,
+    counts: {
+      fourth_send_chars: fourthResume?.send_chars ?? 0,
+      unique_agents: agentIds.length,
+      resume_reason_store: fourthResume?.reason === "exact_successor_store" ? 1 : 0,
+      cache_read: fourth.usage?.cache_read_input_tokens ?? 0,
+    },
+    reason: restartOk ? undefined : "restart_did_not_resume_current_turn",
+  });
+  return cases;
+}
+
+async function runPadded(child: ChildGateway, apiKey: string, timeoutMs: number): Promise<CaseRecord> {
+  const model = "grok-4.6";
+  const pad = "x".repeat(4096);
+  const firstUser = `Ignore the padding and reply with the single word PONG.\nPAD ${pad}`;
+  const secondUser = "Reply with the single word PING and nothing else.";
+  const started = Date.now();
+  const first = await postTurn(child, apiKey, timeoutMs, model, [{ role: "user", content: firstUser }]);
+  if (first.status !== 200 || first.error_type) {
+    return fail(`${model}/ordinary_padded`, first, "padded_first_failed", started);
+  }
+  const second = await postTurn(child, apiKey, timeoutMs, model, [
+    { role: "user", content: firstUser },
+    { role: "assistant", content: assistantContent(first.raw) },
+    { role: "user", content: secondUser },
+  ]);
+  const resume = lastAction(child.stateDir, model, "resume");
+  const rebuilds = tracesFor(child.stateDir, model).filter((item) => item.action === "rebuild");
+  const paddedRebuild = rebuilds.find((item) => (item.send_chars ?? 0) >= 4096);
+  const ok =
+    second.status === 200 &&
+    !second.error_type &&
+    (resume?.reason ?? "").startsWith("exact_successor") &&
+    currentTurnOk(resume?.send_chars ?? 0, secondUser) &&
+    (paddedRebuild?.send_chars ?? 0) >= 4096 &&
+    (resume?.send_chars ?? 0) < 80;
+  return {
+    id: `${model}/ordinary_padded`,
+    status: ok ? "pass" : "fail",
+    http_status: second.status,
+    error_type: second.error_type,
+    duration_ms: Date.now() - started,
+    usage: second.usage,
+    counts: {
+      padded_first_send_chars: paddedRebuild?.send_chars ?? 0,
+      padded_second_send_chars: resume?.send_chars ?? 0,
+      cache_read: second.usage?.cache_read_input_tokens ?? 0,
+    },
+    reason: ok ? undefined : "padded_history_was_reflattened",
+  };
+}
+
+await main();


### PR DESCRIPTION
## Summary
- Align ordinary turns with BeefAPI's Cursor Agent contract: typed turn IR, exact-lineage Agent reuse, and `send(current turn)` instead of flattening the whole transcript every request.
- Keep tool continuation, `x-cursor-session-id` follow-up, fork/cold rebuild, and fail-closed replay after restart.
- Add `npm run live:ordinary` for credentialed successor / restart / padded-history proof. Disable with `ORDINARY_TURN_COORDINATOR=0`.

## Test plan
- [x] `npm test` 206/206
- [x] `npm run typecheck` and `npm run build`
- [x] Live `grok-4.6` and `composer-2.5`: successor, third turn, process restart, 4KB padded history (second send 49 chars, cache_read present)
- [ ] CI typecheck/test/build/docker