### PR TITLE
Derive exhausted Cursor quota and label partial console quota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `/v1/account` derives `limits.remaining_usd` from the included limit minus the included spend when Cursor omits `planUsage.remaining` at zero, so an exhausted allowance renders as a real quota instead of a raw payload dump in the Operator Console. `limits.used_percent` is now absent when its inputs are missing or contradict the limit, instead of silently switching to the different `totalPercentUsed` denominator, and null-like usage fields stay unreported rather than coercing to a confident zero.
+
 - Ordinary turns now follow BeefAPI's Cursor Agent contract: a typed turn IR, exact-lineage Agent reuse, and `send(current turn)` instead of flattening the whole transcript on every request. Tool continuation, `x-cursor-session-id` follow-up, and cold rebuild remain. Disable with `ORDINARY_TURN_COORDINATOR=0`.
 
 - `/v1/messages` accepts sub2api compatibility roles without flattening the transcript: `system`/`developer` remain in order, historical `tool`/`function` output stays visible to the Harness, and a trailing tool result requires a real call id before entering continuation lookup.

--- a/src/account/cursor-dashboard.ts
+++ b/src/account/cursor-dashboard.ts
@@ -79,6 +79,9 @@ class DashboardResponseError extends Error {
 const activeExchanges = new Map<string, Promise<string>>();
 
 function optionalNumber(value: unknown): number | undefined {
+  // Number(null), Number(""), Number(false) and Number([]) are a finite 0 the RPC never sent.
+  if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+  if (typeof value !== "string" || !value.trim()) return undefined;
   const number = Number(value);
   return Number.isFinite(number) ? number : undefined;
 }
@@ -284,10 +287,27 @@ export async function fetchCursorDashboardQuota(
     const spendLimitUsage = (usagePayload.spendLimitUsage ?? {}) as Record<string, unknown>;
     const planInfo = (planPayload.planInfo ?? {}) as Record<string, unknown>;
     const limitCents = ownNumber(planUsage, "limit");
-    const remainingCents = ownNumber(planUsage, "remaining");
+    let remainingCents = ownNumber(planUsage, "remaining");
     let usedCents = ownNumber(planUsage, "includedSpend");
-    if (usedCents === undefined && limitCents !== undefined && remainingCents !== undefined) {
-      usedCents = Math.max(0, limitCents - remainingCents);
+    // A spend below zero is not a spend, and Cursor omits planUsage.remaining once the
+    // allowance is exhausted; derive the missing side only from a pair that adds up.
+    if (usedCents !== undefined && usedCents < 0) usedCents = undefined;
+    if (
+      usedCents === undefined &&
+      limitCents !== undefined &&
+      remainingCents !== undefined &&
+      remainingCents >= 0 &&
+      remainingCents <= limitCents
+    ) {
+      usedCents = limitCents - remainingCents;
+    }
+    if (
+      remainingCents === undefined &&
+      limitCents !== undefined &&
+      usedCents !== undefined &&
+      usedCents <= limitCents
+    ) {
+      remainingCents = limitCents - usedCents;
     }
     const totalSpendCents = ownNumber(planUsage, "totalSpend");
     const cursorModelsPercentUsed = ownNumber(planUsage, "totalPercentUsed");
@@ -304,9 +324,11 @@ export async function fetchCursorDashboardQuota(
     ].every((value) => value === undefined)) {
       return { available: false, source: "cursor_dashboard_rpc", reason: "dashboard_invalid_response" };
     }
-    const usedPercent = limitCents !== undefined && limitCents > 0 && usedCents !== undefined
-      ? (usedCents / limitCents) * 100
-      : cursorModelsPercentUsed;
+    // totalPercentUsed is a different denominator, and a spend past the limit is no fraction of it.
+    const usedPercent =
+      limitCents !== undefined && limitCents > 0 && usedCents !== undefined && usedCents <= limitCents
+        ? (usedCents / limitCents) * 100
+        : undefined;
     const cents = (record: Record<string, unknown>, key: string): number | undefined => {
       const value = ownNumber(record, key);
       return value === undefined ? undefined : value / 100;

--- a/tests/contract/console-operator.test.ts
+++ b/tests/contract/console-operator.test.ts
@@ -75,6 +75,104 @@ test("quota formatter keeps Cursor and Claude-family usage percentages separate"
   ).toBe("Cursor Models 1.0% · Other Models 5.2%");
 });
 
+test("quota breakdown skips a percentage the gateway never reported", () => {
+  expect(
+    formatQuotaBreakdown({
+      status: "ok",
+      identity: { api_key_name: "local-dev" },
+      spending: { plan_name: "Ultra" },
+      limits: { cursor_models_percent_used: null, other_models_percent_used: 5.16 },
+      capabilities: { identity: true, spending: true, limits: true },
+    }),
+  ).toBe("Other Models 5.2%");
+});
+
+test("quota formatter labels a known limit instead of dumping raw payload keys", () => {
+  const quota = formatQuota({
+    status: "ok",
+    identity: { api_key_name: "local-dev" },
+    spending: { source: "cursor_dashboard_rpc", plan_name: "Pro", plan_owner: "PLAN_OWNER_STRIPE" },
+    limits: { limit_usd: 20, billing_cycle_start: "1700000000000", cursor_models_percent_used: 10 },
+    capabilities: { identity: true, spending: true, limits: true },
+  });
+
+  expect(quota).not.toContain("billing_cycle_start");
+  expect(quota).not.toContain("plan_owner");
+  expect(quota).toBe("$20.00 limit");
+});
+
+test("quota formatter keeps a known spend and limit when remaining is unreported", () => {
+  expect(
+    formatQuota({
+      status: "ok",
+      identity: { api_key_name: "local-dev" },
+      spending: { plan_name: "Pro", used_usd: 12 },
+      limits: { limit_usd: 20, cursor_models_percent_used: 10 },
+      capabilities: { identity: true, spending: true, limits: true },
+    }),
+  ).toBe("$12.00 used / $20.00 limit");
+});
+
+test("quota formatter respects a payload that declares spending and limits unavailable", () => {
+  expect(
+    formatQuota({
+      status: "partial",
+      identity: { api_key_name: "local-dev" },
+      spending: { used_usd: 12 },
+      limits: { limit_usd: 20 },
+      capabilities: { identity: true, spending: false, limits: false },
+    }),
+  ).toBe("");
+});
+
+test("quota formatter reports nothing when no dollar field is recognized", () => {
+  expect(
+    formatQuota({
+      status: "ok",
+      identity: { api_key_name: "local-dev" },
+      spending: { source: "cursor_dashboard_rpc", plan_name: "Pro" },
+      limits: { billing_cycle_start: "1700000000000", cursor_models_percent_used: 10 },
+      capabilities: { identity: true, spending: true, limits: true },
+    }),
+  ).toBe("");
+});
+
+test("quota formatter never renders a null dollar field as zero", () => {
+  expect(
+    formatQuota({
+      status: "ok",
+      identity: { api_key_name: "local-dev" },
+      spending: { used_usd: null },
+      limits: { remaining_usd: null, limit_usd: 20 },
+      capabilities: { identity: true, spending: true, limits: true },
+    }),
+  ).toBe("$20.00 limit");
+});
+
+test("quota formatter does not publish an all-zero spend and limit as real usage", () => {
+  expect(
+    formatQuota({
+      status: "ok",
+      identity: { api_key_name: "local-dev" },
+      spending: { used_usd: 0 },
+      limits: { limit_usd: 0 },
+      capabilities: { identity: true, spending: true, limits: true },
+    }),
+  ).toBe("");
+});
+
+test("quota formatter suppresses a zero remaining and limit even when a spend is known", () => {
+  expect(
+    formatQuota({
+      status: "ok",
+      identity: { api_key_name: "local-dev" },
+      spending: { used_usd: 5 },
+      limits: { remaining_usd: 0, limit_usd: 0 },
+      capabilities: { identity: true, spending: true, limits: true },
+    }),
+  ).toBe("");
+});
+
 test("key mask keeps the edges and hides the middle", () => {
   expect(maskKey("cursor_abcdefghijklmnop")).toBe("cursor…mnop");
 });

--- a/tests/sdk/cursor-dashboard.test.ts
+++ b/tests/sdk/cursor-dashboard.test.ts
@@ -3,6 +3,10 @@ import type { AddressInfo } from "node:net";
 import { brotliCompressSync } from "node:zlib";
 import { afterEach, expect, test } from "vitest";
 import { fetchCursorDashboardQuota } from "../../src/account/cursor-dashboard.js";
+import { readAccount } from "../../src/account/service.js";
+import type { SdkAccountResult, SdkRuntime } from "../../src/sdk/port.js";
+import { formatQuota } from "../../web/src/quota.js";
+import type { AccountPayload } from "../../web/src/types.js";
 
 const servers: ReturnType<typeof createServer>[] = [];
 
@@ -233,4 +237,269 @@ test("decodes Cursor dashboard Brotli bytes when a proxy strips Content-Encoding
     remainingUsd: 9,
     limitUsd: 10,
   });
+});
+
+test("derives an exhausted included allowance that the dashboard omits", async () => {
+  const baseUrl = await dashboardServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/auth/exchange_user_api_key") {
+      response.end(JSON.stringify({ accessToken: "access" }));
+      return;
+    }
+    if (request.url?.endsWith("/GetCurrentPeriodUsage")) {
+      response.end(JSON.stringify({
+        planUsage: {
+          totalSpend: 3450,
+          includedSpend: 2000,
+          bonusSpend: 1450,
+          limit: 2000,
+          autoPercentUsed: 4,
+          apiPercentUsed: 50,
+          totalPercentUsed: 10,
+        },
+      }));
+      return;
+    }
+    response.end(JSON.stringify({ planInfo: { planName: "Pro", price: "$20/mo" } }));
+  });
+
+  const quota = await fetchCursorDashboardQuota("key", { baseUrl });
+
+  expect(quota).toMatchObject({
+    available: true,
+    usedUsd: 20,
+    remainingUsd: 0,
+    limitUsd: 20,
+    bonusSpendUsd: 14.5,
+    usedPercent: 100,
+  });
+});
+
+test("leaves remaining unreported when the included spend is unknown", async () => {
+  const baseUrl = await dashboardServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/auth/exchange_user_api_key") {
+      response.end(JSON.stringify({ accessToken: "access" }));
+      return;
+    }
+    if (request.url?.endsWith("/GetCurrentPeriodUsage")) {
+      response.end(JSON.stringify({ planUsage: { totalSpend: 1200, limit: 2000, totalPercentUsed: 3.478 } }));
+      return;
+    }
+    response.end(JSON.stringify({ planInfo: { planName: "Pro" } }));
+  });
+
+  const quota = await fetchCursorDashboardQuota("key", { baseUrl });
+
+  expect(quota).toMatchObject({ available: true, totalSpendUsd: 12, limitUsd: 20 });
+  if (quota.available) expect(quota.remainingUsd).toBeUndefined();
+});
+
+test("omits used percent instead of reporting the total usage axis under the same name", async () => {
+  const baseUrl = await dashboardServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/auth/exchange_user_api_key") {
+      response.end(JSON.stringify({ accessToken: "access" }));
+      return;
+    }
+    if (request.url?.endsWith("/GetCurrentPeriodUsage")) {
+      response.end(JSON.stringify({
+        planUsage: { totalSpend: 500, apiPercentUsed: 2.1, totalPercentUsed: 1.449 },
+      }));
+      return;
+    }
+    response.end(JSON.stringify({ planInfo: { planName: "Pro" } }));
+  });
+
+  const quota = await fetchCursorDashboardQuota("key", { baseUrl });
+
+  expect(quota).toMatchObject({ available: true, totalSpendUsd: 5, cursorModelsPercentUsed: 1.449 });
+  if (quota.available) expect(quota.usedPercent).toBeUndefined();
+});
+
+test("treats null-like usage fields as unreported instead of zero", async () => {
+  const baseUrl = await dashboardServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/auth/exchange_user_api_key") {
+      response.end(JSON.stringify({ accessToken: "access" }));
+      return;
+    }
+    if (request.url?.endsWith("/GetCurrentPeriodUsage")) {
+      response.end(JSON.stringify({
+        planUsage: {
+          limit: 2000,
+          includedSpend: null,
+          remaining: "",
+          totalSpend: false,
+          apiPercentUsed: [],
+          autoPercentUsed: {},
+          totalPercentUsed: 1.5,
+        },
+      }));
+      return;
+    }
+    response.end(JSON.stringify({ planInfo: { planName: "Pro" } }));
+  });
+
+  const quota = await fetchCursorDashboardQuota("key", { baseUrl });
+
+  expect(quota).toMatchObject({ available: true, limitUsd: 20, cursorModelsPercentUsed: 1.5 });
+  if (quota.available) {
+    expect(quota.usedUsd).toBeUndefined();
+    expect(quota.remainingUsd).toBeUndefined();
+    expect(quota.totalSpendUsd).toBeUndefined();
+    expect(quota.usedPercent).toBeUndefined();
+    expect(quota.otherModelsPercentUsed).toBeUndefined();
+    expect(quota.autoModelsPercentUsed).toBeUndefined();
+  }
+});
+
+test("fails closed when every current-period usage field is null-like", async () => {
+  const baseUrl = await dashboardServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/auth/exchange_user_api_key") {
+      response.end(JSON.stringify({ accessToken: "access" }));
+      return;
+    }
+    if (request.url?.endsWith("/GetCurrentPeriodUsage")) {
+      response.end(JSON.stringify({
+        planUsage: { limit: null, remaining: "", includedSpend: false, totalSpend: [] },
+      }));
+      return;
+    }
+    response.end(JSON.stringify({ planInfo: { planName: "Pro" } }));
+  });
+
+  const quota = await fetchCursorDashboardQuota("key", { baseUrl });
+
+  expect(quota).toEqual({
+    available: false,
+    source: "cursor_dashboard_rpc",
+    reason: "dashboard_invalid_response",
+  });
+});
+
+test("reads a numeric usage string as a number", async () => {
+  const baseUrl = await dashboardServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/auth/exchange_user_api_key") {
+      response.end(JSON.stringify({ accessToken: "access" }));
+      return;
+    }
+    if (request.url?.endsWith("/GetCurrentPeriodUsage")) {
+      response.end(JSON.stringify({ planUsage: { limit: "2000", includedSpend: "500" } }));
+      return;
+    }
+    response.end(JSON.stringify({ planInfo: { planName: "Pro" } }));
+  });
+
+  const quota = await fetchCursorDashboardQuota("key", { baseUrl });
+
+  expect(quota).toMatchObject({ available: true, usedUsd: 5, remainingUsd: 15, limitUsd: 20, usedPercent: 25 });
+});
+
+test("publishes an over-limit included spend without a percentage and drops a negative one", async () => {
+  const usage = async (planUsage: Record<string, unknown>) => {
+    const baseUrl = await dashboardServer((request, response) => {
+      response.setHeader("content-type", "application/json");
+      if (request.url === "/auth/exchange_user_api_key") {
+        response.end(JSON.stringify({ accessToken: "access" }));
+        return;
+      }
+      if (request.url?.endsWith("/GetCurrentPeriodUsage")) {
+        response.end(JSON.stringify({ planUsage }));
+        return;
+      }
+      response.end(JSON.stringify({ planInfo: { planName: "Pro" } }));
+    });
+    return fetchCursorDashboardQuota("key", { baseUrl });
+  };
+
+  const overLimit = await usage({ limit: 2000, includedSpend: 2500 });
+  const negative = await usage({ limit: 2000, includedSpend: -500 });
+
+  expect(overLimit).toMatchObject({ available: true, usedUsd: 25, limitUsd: 20 });
+  if (overLimit.available) {
+    expect(overLimit.remainingUsd).toBeUndefined();
+    expect(overLimit.usedPercent).toBeUndefined();
+  }
+  expect(negative).toMatchObject({ available: true, limitUsd: 20 });
+  if (negative.available) {
+    expect(negative.usedUsd).toBeUndefined();
+    expect(negative.remainingUsd).toBeUndefined();
+    expect(negative.usedPercent).toBeUndefined();
+  }
+});
+
+test("leaves used unreported when the remaining amount contradicts the limit", async () => {
+  const baseUrl = await dashboardServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/auth/exchange_user_api_key") {
+      response.end(JSON.stringify({ accessToken: "access" }));
+      return;
+    }
+    if (request.url?.endsWith("/GetCurrentPeriodUsage")) {
+      response.end(JSON.stringify({ planUsage: { limit: 2000, remaining: 5000 } }));
+      return;
+    }
+    response.end(JSON.stringify({ planInfo: { planName: "Pro" } }));
+  });
+
+  const quota = await fetchCursorDashboardQuota("key", { baseUrl });
+
+  expect(quota).toMatchObject({ available: true, remainingUsd: 50, limitUsd: 20 });
+  if (quota.available) {
+    expect(quota.usedUsd).toBeUndefined();
+    expect(quota.usedPercent).toBeUndefined();
+  }
+});
+
+async function consoleQuotaCell(planUsage: Record<string, unknown>): Promise<string> {
+  const baseUrl = await dashboardServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/auth/exchange_user_api_key") {
+      response.end(JSON.stringify({ accessToken: "access" }));
+      return;
+    }
+    if (request.url?.endsWith("/GetCurrentPeriodUsage")) {
+      response.end(JSON.stringify({ planUsage }));
+      return;
+    }
+    response.end(JSON.stringify({ planInfo: { planName: "Pro" } }));
+  });
+  const quota = await fetchCursorDashboardQuota("key", { baseUrl });
+  if (!quota.available) throw new Error(quota.reason);
+  const compactRecord = (record: Record<string, unknown>): Record<string, unknown> =>
+    Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined));
+  const account: SdkAccountResult = {
+    ok: true,
+    identity: { apiKeyName: "local-dev" },
+    spending: compactRecord({
+      source: quota.source,
+      plan_name: quota.planName,
+      used_usd: quota.usedUsd,
+      total_spend_usd: quota.totalSpendUsd,
+      bonus_spend_usd: quota.bonusSpendUsd,
+    }),
+    limits: compactRecord({
+      remaining_usd: quota.remainingUsd,
+      limit_usd: quota.limitUsd,
+      used_percent: quota.usedPercent,
+      cursor_models_percent_used: quota.cursorModelsPercentUsed,
+      other_models_percent_used: quota.otherModelsPercentUsed,
+    }),
+  };
+  const sdk = { getAccount: async () => account } as unknown as SdkRuntime;
+  return formatQuota((await readAccount(sdk, "key")) as unknown as AccountPayload);
+}
+
+test("carries adapter output through the account payload into the console quota cell", async () => {
+  expect(await consoleQuotaCell({
+    totalSpend: 3450,
+    includedSpend: 2000,
+    bonusSpend: 1450,
+    limit: 2000,
+    totalPercentUsed: 10,
+  })).toBe("$0.00 / $20.00");
+  expect(await consoleQuotaCell({ totalSpend: 500, apiPercentUsed: 2.1, totalPercentUsed: 1.449 })).toBe("");
 });

--- a/web/src/quota.ts
+++ b/web/src/quota.ts
@@ -1,19 +1,9 @@
 import type { AccountPayload } from "./types.js";
 
-function compactValue(value: unknown): string {
-  if (value == null) return "";
-  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return String(value);
-  if (Array.isArray(value)) return value.map(compactValue).filter(Boolean).join(", ");
-  if (typeof value === "object") {
-    return Object.entries(value as Record<string, unknown>)
-      .slice(0, 4)
-      .map(([key, inner]) => `${key} ${compactValue(inner)}`)
-      .join(" · ");
-  }
-  return "";
-}
-
 function finiteNumber(value: unknown): number | undefined {
+  // Number(null), Number("") and Number(false) are a finite 0 the gateway never reported.
+  if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+  if (typeof value !== "string" || !value.trim()) return undefined;
   const number = Number(value);
   return Number.isFinite(number) ? number : undefined;
 }
@@ -29,10 +19,13 @@ export function formatQuota(account?: AccountPayload): string {
   if (remaining === 0 && limit === 0) return "";
   if (remaining !== undefined && limit !== undefined) return `${usd(remaining)} / ${usd(limit)}`;
   if (remaining !== undefined) return usd(remaining);
+  const used = account.capabilities.spending ? finiteNumber(account.spending?.used_usd) : undefined;
+  const knownLimit = account.capabilities.limits ? limit : undefined;
+  if ([used, knownLimit].every((value) => value === undefined || value === 0)) return "";
   const parts: string[] = [];
-  if (account.capabilities.spending && account.spending) parts.push(compactValue(account.spending));
-  if (account.capabilities.limits && account.limits) parts.push(compactValue(account.limits));
-  return parts.filter(Boolean).join(" · ");
+  if (used !== undefined) parts.push(`${usd(used)} used`);
+  if (knownLimit !== undefined) parts.push(`${usd(knownLimit)} limit`);
+  return parts.join(" / ");
 }
 
 export function formatQuotaBreakdown(account?: AccountPayload): string {


### PR DESCRIPTION
Fixes #19.

## What

`GetCurrentPeriodUsage` omits `planUsage.remaining` when it is zero, so an account that has spent its whole included allowance loses `limits.remaining_usd`. Both dollar branches of `formatQuota()` are gated on that field, so the quota cell fell through to `compactValue()` and rendered a raw snake_case dump — `source cursor_dashboard_rpc · plan_name Pro · plan_price $20/mo · plan_owner PLAN_OWNER_STRIPE · limit_usd 20 · …` — under the `Quota` label, with `.slice(0, 4)` truncating away the very fields that would have explained the state. Separately, `limits.used_percent` was `includedSpend / limit` when `limit` was present and silently became `totalPercentUsed` otherwise: two upstream quantities with different denominators under one name.

- `src/account/cursor-dashboard.ts`: derive `remaining` from `limit - includedSpend`, the mirror of the derivation that already existed in the opposite direction. The two are mutually exclusive, and the new one only fires when `limitCents` is already defined, so the fail-closed "every usage field undefined" guard is untouched.
- `src/account/cursor-dashboard.ts`: harden `optionalNumber` so only a real finite JSON number is accepted. `Number(null)`, `Number("")`, `Number(false)` and `Number([])` are all a finite `0` the RPC never sent, and that phantom zero is what let drift read as a confident quota. Numeric strings are still accepted — that is inherited behaviour from `main`, not a claim about the upstream contract.
- `src/account/cursor-dashboard.ts`: omit `used_percent` when its inputs are absent instead of falling back to `totalPercentUsed`.
- `web/src/quota.ts`: label the recognized dollar fields (`$12.00 used / $20.00 limit`) instead of dumping payload keys, and reserve the empty string for a payload with nothing recognizable. `compactValue()` had no other caller and is deleted.

## `/v1/account` contract change

`limits.used_percent` can now be **absent** where it was previously always populated: it is the included-allowance fraction only, never a fallback to a different denominator, and it is omitted when the limit is missing or zero, when the included spend is unknown, or when that spend exceeds the limit. `limits.remaining_usd` now **appears** for an exhausted account. Either side is derived only from a non-negative pair that adds up; drift is never clamped.

## Fail-closed monetary invariants

A negative included spend is dropped rather than published, so `used_usd`, the derived `remaining_usd` and `used_percent` all stay absent instead of rendering `$-5.00 used / $20.00 limit`. An included spend **above** the limit keeps `used_usd` — Cursor reported that figure, and bonus/on-demand overflow makes a spend past the included allowance a real reading — but yields no `used_percent` and no derived `remaining_usd`, so no percentage above 100 is ever emitted.

The `capabilities.spending` / `capabilities.limits` gate that guarded the old fallback is preserved, matching `formatQuotaBreakdown`: an account that declares those surfaces unavailable still renders nothing.

## Shared helper side effect

Hardening `finiteNumber` in `web/src/quota.ts` also changes `formatQuotaBreakdown`: a null percentage now skips instead of rendering `0.0%`. Pinned by `quota breakdown skips a percentage the gateway never reported`.

## Known gap, deliberately not closed

A negative `planUsage.remaining` still reaches `remainingUsd`, and a remaining **above** the limit is deliberately published (pinned by `leaves used unreported when the remaining amount contradicts the limit`). Closing the negative side without the over-limit side would be incoherent, and closing both would change a branch behaviour no reviewer flagged. Flagging it rather than silently half-fixing it.

## Verified

```
npx tsc -p tsconfig.json --noEmit      # clean
npx tsc -p web/tsconfig.json --noEmit  # clean
npx vitest run                         # 31 files, 223 tests (206 baseline + 17)
bash tests/secret-scan.sh              # no leaks found
```

New coverage includes the end-to-end case the issue asked for — real adapter → `compactRecord` account payload → `readAccount` → `formatQuota` — asserting `$0.00 / $20.00` for the exhausted account and `""` for a percentages-only one. Every pre-existing test passes unchanged.
