### PR TITLE
Render the auto meter and on-demand dollars in the quota breakdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `/v1/account` derives `limits.remaining_usd` from the included limit minus the included spend when Cursor omits `planUsage.remaining` at zero, so an exhausted allowance renders as a real quota instead of a raw payload dump in the Operator Console. `limits.used_percent` is now absent when its inputs are missing or contradict the limit, instead of silently switching to the different `totalPercentUsed` denominator, and null-like usage fields stay unreported rather than coercing to a confident zero.
+
 - Ordinary turns now follow BeefAPI's Cursor Agent contract: a typed turn IR, exact-lineage Agent reuse, and `send(current turn)` instead of flattening the whole transcript on every request. Tool continuation, `x-cursor-session-id` follow-up, and cold rebuild remain. Disable with `ORDINARY_TURN_COORDINATOR=0`.
 
 - `/v1/messages` accepts sub2api compatibility roles without flattening the transcript: `system`/`developer` remain in order, historical `tool`/`function` output stays visible to the Harness, and a trailing tool result requires a real call id before entering continuation lookup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - `/v1/account` derives `limits.remaining_usd` from the included limit minus the included spend when Cursor omits `planUsage.remaining` at zero, so an exhausted allowance renders as a real quota instead of a raw payload dump in the Operator Console. `limits.used_percent` is now absent when its inputs are missing or contradict the limit, instead of silently switching to the different `totalPercentUsed` denominator, and null-like usage fields stay unreported rather than coercing to a confident zero.
 
+- The Operator Console quota breakdown now draws `auto_models_percent_used` and the six `on_demand_*` dollar fields the account payload already carried, keeping individual and pooled scopes separate and treating an all-zero scope as an unconfigured spend limit rather than an exhausted budget. `on_demand_limit_type` and `on_demand_spend_usd` remain undrawn.
+
 - Ordinary turns now follow BeefAPI's Cursor Agent contract: a typed turn IR, exact-lineage Agent reuse, and `send(current turn)` instead of flattening the whole transcript on every request. Tool continuation, `x-cursor-session-id` follow-up, and cold rebuild remain. Disable with `ORDINARY_TURN_COORDINATOR=0`.
 
 - `/v1/messages` accepts sub2api compatibility roles without flattening the transcript: `system`/`developer` remain in order, historical `tool`/`function` output stays visible to the Harness, and a trailing tool result requires a real call id before entering continuation lookup.

--- a/src/account/cursor-dashboard.ts
+++ b/src/account/cursor-dashboard.ts
@@ -79,6 +79,9 @@ class DashboardResponseError extends Error {
 const activeExchanges = new Map<string, Promise<string>>();
 
 function optionalNumber(value: unknown): number | undefined {
+  // Number(null), Number(""), Number(false) and Number([]) are a finite 0 the RPC never sent.
+  if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+  if (typeof value !== "string" || !value.trim()) return undefined;
   const number = Number(value);
   return Number.isFinite(number) ? number : undefined;
 }
@@ -284,10 +287,27 @@ export async function fetchCursorDashboardQuota(
     const spendLimitUsage = (usagePayload.spendLimitUsage ?? {}) as Record<string, unknown>;
     const planInfo = (planPayload.planInfo ?? {}) as Record<string, unknown>;
     const limitCents = ownNumber(planUsage, "limit");
-    const remainingCents = ownNumber(planUsage, "remaining");
+    let remainingCents = ownNumber(planUsage, "remaining");
     let usedCents = ownNumber(planUsage, "includedSpend");
-    if (usedCents === undefined && limitCents !== undefined && remainingCents !== undefined) {
-      usedCents = Math.max(0, limitCents - remainingCents);
+    // A spend below zero is not a spend, and Cursor omits planUsage.remaining once the
+    // allowance is exhausted; derive the missing side only from a pair that adds up.
+    if (usedCents !== undefined && usedCents < 0) usedCents = undefined;
+    if (
+      usedCents === undefined &&
+      limitCents !== undefined &&
+      remainingCents !== undefined &&
+      remainingCents >= 0 &&
+      remainingCents <= limitCents
+    ) {
+      usedCents = limitCents - remainingCents;
+    }
+    if (
+      remainingCents === undefined &&
+      limitCents !== undefined &&
+      usedCents !== undefined &&
+      usedCents <= limitCents
+    ) {
+      remainingCents = limitCents - usedCents;
     }
     const totalSpendCents = ownNumber(planUsage, "totalSpend");
     const cursorModelsPercentUsed = ownNumber(planUsage, "totalPercentUsed");
@@ -304,9 +324,11 @@ export async function fetchCursorDashboardQuota(
     ].every((value) => value === undefined)) {
       return { available: false, source: "cursor_dashboard_rpc", reason: "dashboard_invalid_response" };
     }
-    const usedPercent = limitCents !== undefined && limitCents > 0 && usedCents !== undefined
-      ? (usedCents / limitCents) * 100
-      : cursorModelsPercentUsed;
+    // totalPercentUsed is a different denominator, and a spend past the limit is no fraction of it.
+    const usedPercent =
+      limitCents !== undefined && limitCents > 0 && usedCents !== undefined && usedCents <= limitCents
+        ? (usedCents / limitCents) * 100
+        : undefined;
     const cents = (record: Record<string, unknown>, key: string): number | undefined => {
       const value = ownNumber(record, key);
       return value === undefined ? undefined : value / 100;

--- a/tests/contract/console-operator.test.ts
+++ b/tests/contract/console-operator.test.ts
@@ -75,6 +75,104 @@ test("quota formatter keeps Cursor and Claude-family usage percentages separate"
   ).toBe("Cursor Models 1.0% · Other Models 5.2%");
 });
 
+test("quota breakdown skips a percentage the gateway never reported", () => {
+  expect(
+    formatQuotaBreakdown({
+      status: "ok",
+      identity: { api_key_name: "local-dev" },
+      spending: { plan_name: "Ultra" },
+      limits: { cursor_models_percent_used: null, other_models_percent_used: 5.16 },
+      capabilities: { identity: true, spending: true, limits: true },
+    }),
+  ).toBe("Other Models 5.2%");
+});
+
+test("quota formatter labels a known limit instead of dumping raw payload keys", () => {
+  const quota = formatQuota({
+    status: "ok",
+    identity: { api_key_name: "local-dev" },
+    spending: { source: "cursor_dashboard_rpc", plan_name: "Pro", plan_owner: "PLAN_OWNER_STRIPE" },
+    limits: { limit_usd: 20, billing_cycle_start: "1700000000000", cursor_models_percent_used: 10 },
+    capabilities: { identity: true, spending: true, limits: true },
+  });
+
+  expect(quota).not.toContain("billing_cycle_start");
+  expect(quota).not.toContain("plan_owner");
+  expect(quota).toBe("$20.00 limit");
+});
+
+test("quota formatter keeps a known spend and limit when remaining is unreported", () => {
+  expect(
+    formatQuota({
+      status: "ok",
+      identity: { api_key_name: "local-dev" },
+      spending: { plan_name: "Pro", used_usd: 12 },
+      limits: { limit_usd: 20, cursor_models_percent_used: 10 },
+      capabilities: { identity: true, spending: true, limits: true },
+    }),
+  ).toBe("$12.00 used / $20.00 limit");
+});
+
+test("quota formatter respects a payload that declares spending and limits unavailable", () => {
+  expect(
+    formatQuota({
+      status: "partial",
+      identity: { api_key_name: "local-dev" },
+      spending: { used_usd: 12 },
+      limits: { limit_usd: 20 },
+      capabilities: { identity: true, spending: false, limits: false },
+    }),
+  ).toBe("");
+});
+
+test("quota formatter reports nothing when no dollar field is recognized", () => {
+  expect(
+    formatQuota({
+      status: "ok",
+      identity: { api_key_name: "local-dev" },
+      spending: { source: "cursor_dashboard_rpc", plan_name: "Pro" },
+      limits: { billing_cycle_start: "1700000000000", cursor_models_percent_used: 10 },
+      capabilities: { identity: true, spending: true, limits: true },
+    }),
+  ).toBe("");
+});
+
+test("quota formatter never renders a null dollar field as zero", () => {
+  expect(
+    formatQuota({
+      status: "ok",
+      identity: { api_key_name: "local-dev" },
+      spending: { used_usd: null },
+      limits: { remaining_usd: null, limit_usd: 20 },
+      capabilities: { identity: true, spending: true, limits: true },
+    }),
+  ).toBe("$20.00 limit");
+});
+
+test("quota formatter does not publish an all-zero spend and limit as real usage", () => {
+  expect(
+    formatQuota({
+      status: "ok",
+      identity: { api_key_name: "local-dev" },
+      spending: { used_usd: 0 },
+      limits: { limit_usd: 0 },
+      capabilities: { identity: true, spending: true, limits: true },
+    }),
+  ).toBe("");
+});
+
+test("quota formatter suppresses a zero remaining and limit even when a spend is known", () => {
+  expect(
+    formatQuota({
+      status: "ok",
+      identity: { api_key_name: "local-dev" },
+      spending: { used_usd: 5 },
+      limits: { remaining_usd: 0, limit_usd: 0 },
+      capabilities: { identity: true, spending: true, limits: true },
+    }),
+  ).toBe("");
+});
+
 test("key mask keeps the edges and hides the middle", () => {
   expect(maskKey("cursor_abcdefghijklmnop")).toBe("cursor…mnop");
 });

--- a/tests/contract/console-operator.test.ts
+++ b/tests/contract/console-operator.test.ts
@@ -173,6 +173,69 @@ test("quota formatter suppresses a zero remaining and limit even when a spend is
   ).toBe("");
 });
 
+test("quota breakdown renders the auto meter and both on-demand scopes", () => {
+  expect(
+    formatQuotaBreakdown({
+      status: "ok",
+      identity: { api_key_name: "local-dev" },
+      spending: { plan_name: "Ultra" },
+      limits: {
+        cursor_models_percent_used: 1.04,
+        other_models_percent_used: 5.16,
+        auto_models_percent_used: 0.31,
+        on_demand_individual_used: 3,
+        on_demand_individual_remaining: 47,
+        on_demand_individual_limit: 50,
+        on_demand_pooled_used: 12,
+        on_demand_pooled_limit: 200,
+      },
+      capabilities: { identity: true, spending: true, limits: true },
+    }),
+  ).toBe(
+    "Cursor Models 1.0% · Other Models 5.2% · Auto 0.3% · On-demand (individual) $3.00 used, $47.00 remaining, $50.00 limit · On-demand (pooled) $12.00 used, $200.00 limit",
+  );
+});
+
+test("quota breakdown draws no on-demand row from a limit type without reported dollars", () => {
+  expect(
+    formatQuotaBreakdown({
+      status: "ok",
+      identity: { api_key_name: "local-dev" },
+      limits: {
+        cursor_models_percent_used: 1.04,
+        on_demand_limit_type: "individual",
+        on_demand_individual_limit: 0,
+        on_demand_individual_used: 0,
+        on_demand_individual_remaining: 0,
+      },
+      capabilities: { identity: true, spending: false, limits: true },
+    }),
+  ).toBe("Cursor Models 1.0%");
+  expect(
+    formatQuotaBreakdown({
+      status: "ok",
+      identity: { api_key_name: "local-dev" },
+      limits: { on_demand_limit_type: "pooled" },
+      capabilities: { identity: true, spending: false, limits: true },
+    }),
+  ).toBe("");
+});
+
+test("quota breakdown keeps the zero spend of a configured but unused on-demand limit", () => {
+  expect(
+    formatQuotaBreakdown({
+      status: "ok",
+      identity: { api_key_name: "local-dev" },
+      limits: {
+        on_demand_individual_used: 0,
+        on_demand_individual_remaining: 50,
+        on_demand_individual_limit: 50,
+      },
+      capabilities: { identity: true, spending: false, limits: true },
+    }),
+  ).toBe("On-demand (individual) $0.00 used, $50.00 remaining, $50.00 limit");
+});
+
 test("key mask keeps the edges and hides the middle", () => {
   expect(maskKey("cursor_abcdefghijklmnop")).toBe("cursor…mnop");
 });

--- a/tests/sdk/cursor-dashboard.test.ts
+++ b/tests/sdk/cursor-dashboard.test.ts
@@ -5,7 +5,7 @@ import { afterEach, expect, test } from "vitest";
 import { fetchCursorDashboardQuota } from "../../src/account/cursor-dashboard.js";
 import { readAccount } from "../../src/account/service.js";
 import type { SdkAccountResult, SdkRuntime } from "../../src/sdk/port.js";
-import { formatQuota } from "../../web/src/quota.js";
+import { formatQuota, formatQuotaBreakdown } from "../../web/src/quota.js";
 import type { AccountPayload } from "../../web/src/types.js";
 
 const servers: ReturnType<typeof createServer>[] = [];
@@ -502,4 +502,67 @@ test("carries adapter output through the account payload into the console quota 
     totalPercentUsed: 10,
   })).toBe("$0.00 / $20.00");
   expect(await consoleQuotaCell({ totalSpend: 500, apiPercentUsed: 2.1, totalPercentUsed: 1.449 })).toBe("");
+});
+
+async function consoleAccountPayload(usagePayload: Record<string, unknown>): Promise<AccountPayload> {
+  const baseUrl = await dashboardServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/auth/exchange_user_api_key") {
+      response.end(JSON.stringify({ accessToken: "access" }));
+      return;
+    }
+    if (request.url?.endsWith("/GetCurrentPeriodUsage")) {
+      response.end(JSON.stringify(usagePayload));
+      return;
+    }
+    response.end(JSON.stringify({ planInfo: { planName: "Pro" } }));
+  });
+  const quota = await fetchCursorDashboardQuota("key", { baseUrl });
+  if (!quota.available) throw new Error(quota.reason);
+  const compactRecord = (record: Record<string, unknown>): Record<string, unknown> =>
+    Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined));
+  const account: SdkAccountResult = {
+    ok: true,
+    identity: { apiKeyName: "local-dev" },
+    spending: compactRecord({ source: quota.source, on_demand_spend_usd: quota.onDemandSpendUsd }),
+    limits: compactRecord({
+      cursor_models_percent_used: quota.cursorModelsPercentUsed,
+      other_models_percent_used: quota.otherModelsPercentUsed,
+      auto_models_percent_used: quota.autoModelsPercentUsed,
+      on_demand_limit_type: quota.onDemandLimitType,
+      on_demand_individual_limit: quota.onDemandIndividualLimit,
+      on_demand_individual_used: quota.onDemandIndividualUsed,
+      on_demand_individual_remaining: quota.onDemandIndividualRemaining,
+      on_demand_pooled_limit: quota.onDemandPooledLimit,
+      on_demand_pooled_used: quota.onDemandPooledUsed,
+      on_demand_pooled_remaining: quota.onDemandPooledRemaining,
+    }),
+  };
+  const sdk = { getAccount: async () => account } as unknown as SdkRuntime;
+  return (await readAccount(sdk, "key")) as unknown as AccountPayload;
+}
+
+test("carries the auto meter and both on-demand scopes into the console breakdown", async () => {
+  const payload = await consoleAccountPayload({
+    planUsage: { includedSpend: 1250, remaining: 750, limit: 2000, totalPercentUsed: 30, autoPercentUsed: 10, apiPercentUsed: 20 },
+    spendLimitUsage: { limitType: "individual", totalSpend: 300, individualLimit: 5000, individualUsed: 300, individualRemaining: 4700 },
+  });
+
+  expect(payload.spending?.on_demand_spend_usd).toBe(3);
+  expect(formatQuotaBreakdown(payload)).toBe(
+    "Cursor Models 30.0% · Other Models 20.0% · Auto 10.0% · On-demand (individual) $3.00 used, $47.00 remaining, $50.00 limit",
+  );
+});
+
+test("never renders an on-demand dollar the spend limit payload reported as null", async () => {
+  const payload = await consoleAccountPayload({
+    planUsage: { totalPercentUsed: 1.04, apiPercentUsed: 5.16, autoPercentUsed: 0.31 },
+    spendLimitUsage: { limitType: "individual", individualLimit: 5000, individualUsed: null, individualRemaining: null },
+  });
+
+  expect(payload.limits).not.toHaveProperty("on_demand_individual_used");
+  expect(payload.limits).not.toHaveProperty("on_demand_individual_remaining");
+  expect(formatQuotaBreakdown(payload)).toBe(
+    "Cursor Models 1.0% · Other Models 5.2% · Auto 0.3% · On-demand (individual) $50.00 limit",
+  );
 });

--- a/tests/sdk/cursor-dashboard.test.ts
+++ b/tests/sdk/cursor-dashboard.test.ts
@@ -3,6 +3,10 @@ import type { AddressInfo } from "node:net";
 import { brotliCompressSync } from "node:zlib";
 import { afterEach, expect, test } from "vitest";
 import { fetchCursorDashboardQuota } from "../../src/account/cursor-dashboard.js";
+import { readAccount } from "../../src/account/service.js";
+import type { SdkAccountResult, SdkRuntime } from "../../src/sdk/port.js";
+import { formatQuota } from "../../web/src/quota.js";
+import type { AccountPayload } from "../../web/src/types.js";
 
 const servers: ReturnType<typeof createServer>[] = [];
 
@@ -233,4 +237,269 @@ test("decodes Cursor dashboard Brotli bytes when a proxy strips Content-Encoding
     remainingUsd: 9,
     limitUsd: 10,
   });
+});
+
+test("derives an exhausted included allowance that the dashboard omits", async () => {
+  const baseUrl = await dashboardServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/auth/exchange_user_api_key") {
+      response.end(JSON.stringify({ accessToken: "access" }));
+      return;
+    }
+    if (request.url?.endsWith("/GetCurrentPeriodUsage")) {
+      response.end(JSON.stringify({
+        planUsage: {
+          totalSpend: 3450,
+          includedSpend: 2000,
+          bonusSpend: 1450,
+          limit: 2000,
+          autoPercentUsed: 4,
+          apiPercentUsed: 50,
+          totalPercentUsed: 10,
+        },
+      }));
+      return;
+    }
+    response.end(JSON.stringify({ planInfo: { planName: "Pro", price: "$20/mo" } }));
+  });
+
+  const quota = await fetchCursorDashboardQuota("key", { baseUrl });
+
+  expect(quota).toMatchObject({
+    available: true,
+    usedUsd: 20,
+    remainingUsd: 0,
+    limitUsd: 20,
+    bonusSpendUsd: 14.5,
+    usedPercent: 100,
+  });
+});
+
+test("leaves remaining unreported when the included spend is unknown", async () => {
+  const baseUrl = await dashboardServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/auth/exchange_user_api_key") {
+      response.end(JSON.stringify({ accessToken: "access" }));
+      return;
+    }
+    if (request.url?.endsWith("/GetCurrentPeriodUsage")) {
+      response.end(JSON.stringify({ planUsage: { totalSpend: 1200, limit: 2000, totalPercentUsed: 3.478 } }));
+      return;
+    }
+    response.end(JSON.stringify({ planInfo: { planName: "Pro" } }));
+  });
+
+  const quota = await fetchCursorDashboardQuota("key", { baseUrl });
+
+  expect(quota).toMatchObject({ available: true, totalSpendUsd: 12, limitUsd: 20 });
+  if (quota.available) expect(quota.remainingUsd).toBeUndefined();
+});
+
+test("omits used percent instead of reporting the total usage axis under the same name", async () => {
+  const baseUrl = await dashboardServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/auth/exchange_user_api_key") {
+      response.end(JSON.stringify({ accessToken: "access" }));
+      return;
+    }
+    if (request.url?.endsWith("/GetCurrentPeriodUsage")) {
+      response.end(JSON.stringify({
+        planUsage: { totalSpend: 500, apiPercentUsed: 2.1, totalPercentUsed: 1.449 },
+      }));
+      return;
+    }
+    response.end(JSON.stringify({ planInfo: { planName: "Pro" } }));
+  });
+
+  const quota = await fetchCursorDashboardQuota("key", { baseUrl });
+
+  expect(quota).toMatchObject({ available: true, totalSpendUsd: 5, cursorModelsPercentUsed: 1.449 });
+  if (quota.available) expect(quota.usedPercent).toBeUndefined();
+});
+
+test("treats null-like usage fields as unreported instead of zero", async () => {
+  const baseUrl = await dashboardServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/auth/exchange_user_api_key") {
+      response.end(JSON.stringify({ accessToken: "access" }));
+      return;
+    }
+    if (request.url?.endsWith("/GetCurrentPeriodUsage")) {
+      response.end(JSON.stringify({
+        planUsage: {
+          limit: 2000,
+          includedSpend: null,
+          remaining: "",
+          totalSpend: false,
+          apiPercentUsed: [],
+          autoPercentUsed: {},
+          totalPercentUsed: 1.5,
+        },
+      }));
+      return;
+    }
+    response.end(JSON.stringify({ planInfo: { planName: "Pro" } }));
+  });
+
+  const quota = await fetchCursorDashboardQuota("key", { baseUrl });
+
+  expect(quota).toMatchObject({ available: true, limitUsd: 20, cursorModelsPercentUsed: 1.5 });
+  if (quota.available) {
+    expect(quota.usedUsd).toBeUndefined();
+    expect(quota.remainingUsd).toBeUndefined();
+    expect(quota.totalSpendUsd).toBeUndefined();
+    expect(quota.usedPercent).toBeUndefined();
+    expect(quota.otherModelsPercentUsed).toBeUndefined();
+    expect(quota.autoModelsPercentUsed).toBeUndefined();
+  }
+});
+
+test("fails closed when every current-period usage field is null-like", async () => {
+  const baseUrl = await dashboardServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/auth/exchange_user_api_key") {
+      response.end(JSON.stringify({ accessToken: "access" }));
+      return;
+    }
+    if (request.url?.endsWith("/GetCurrentPeriodUsage")) {
+      response.end(JSON.stringify({
+        planUsage: { limit: null, remaining: "", includedSpend: false, totalSpend: [] },
+      }));
+      return;
+    }
+    response.end(JSON.stringify({ planInfo: { planName: "Pro" } }));
+  });
+
+  const quota = await fetchCursorDashboardQuota("key", { baseUrl });
+
+  expect(quota).toEqual({
+    available: false,
+    source: "cursor_dashboard_rpc",
+    reason: "dashboard_invalid_response",
+  });
+});
+
+test("reads a numeric usage string as a number", async () => {
+  const baseUrl = await dashboardServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/auth/exchange_user_api_key") {
+      response.end(JSON.stringify({ accessToken: "access" }));
+      return;
+    }
+    if (request.url?.endsWith("/GetCurrentPeriodUsage")) {
+      response.end(JSON.stringify({ planUsage: { limit: "2000", includedSpend: "500" } }));
+      return;
+    }
+    response.end(JSON.stringify({ planInfo: { planName: "Pro" } }));
+  });
+
+  const quota = await fetchCursorDashboardQuota("key", { baseUrl });
+
+  expect(quota).toMatchObject({ available: true, usedUsd: 5, remainingUsd: 15, limitUsd: 20, usedPercent: 25 });
+});
+
+test("publishes an over-limit included spend without a percentage and drops a negative one", async () => {
+  const usage = async (planUsage: Record<string, unknown>) => {
+    const baseUrl = await dashboardServer((request, response) => {
+      response.setHeader("content-type", "application/json");
+      if (request.url === "/auth/exchange_user_api_key") {
+        response.end(JSON.stringify({ accessToken: "access" }));
+        return;
+      }
+      if (request.url?.endsWith("/GetCurrentPeriodUsage")) {
+        response.end(JSON.stringify({ planUsage }));
+        return;
+      }
+      response.end(JSON.stringify({ planInfo: { planName: "Pro" } }));
+    });
+    return fetchCursorDashboardQuota("key", { baseUrl });
+  };
+
+  const overLimit = await usage({ limit: 2000, includedSpend: 2500 });
+  const negative = await usage({ limit: 2000, includedSpend: -500 });
+
+  expect(overLimit).toMatchObject({ available: true, usedUsd: 25, limitUsd: 20 });
+  if (overLimit.available) {
+    expect(overLimit.remainingUsd).toBeUndefined();
+    expect(overLimit.usedPercent).toBeUndefined();
+  }
+  expect(negative).toMatchObject({ available: true, limitUsd: 20 });
+  if (negative.available) {
+    expect(negative.usedUsd).toBeUndefined();
+    expect(negative.remainingUsd).toBeUndefined();
+    expect(negative.usedPercent).toBeUndefined();
+  }
+});
+
+test("leaves used unreported when the remaining amount contradicts the limit", async () => {
+  const baseUrl = await dashboardServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/auth/exchange_user_api_key") {
+      response.end(JSON.stringify({ accessToken: "access" }));
+      return;
+    }
+    if (request.url?.endsWith("/GetCurrentPeriodUsage")) {
+      response.end(JSON.stringify({ planUsage: { limit: 2000, remaining: 5000 } }));
+      return;
+    }
+    response.end(JSON.stringify({ planInfo: { planName: "Pro" } }));
+  });
+
+  const quota = await fetchCursorDashboardQuota("key", { baseUrl });
+
+  expect(quota).toMatchObject({ available: true, remainingUsd: 50, limitUsd: 20 });
+  if (quota.available) {
+    expect(quota.usedUsd).toBeUndefined();
+    expect(quota.usedPercent).toBeUndefined();
+  }
+});
+
+async function consoleQuotaCell(planUsage: Record<string, unknown>): Promise<string> {
+  const baseUrl = await dashboardServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/auth/exchange_user_api_key") {
+      response.end(JSON.stringify({ accessToken: "access" }));
+      return;
+    }
+    if (request.url?.endsWith("/GetCurrentPeriodUsage")) {
+      response.end(JSON.stringify({ planUsage }));
+      return;
+    }
+    response.end(JSON.stringify({ planInfo: { planName: "Pro" } }));
+  });
+  const quota = await fetchCursorDashboardQuota("key", { baseUrl });
+  if (!quota.available) throw new Error(quota.reason);
+  const compactRecord = (record: Record<string, unknown>): Record<string, unknown> =>
+    Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined));
+  const account: SdkAccountResult = {
+    ok: true,
+    identity: { apiKeyName: "local-dev" },
+    spending: compactRecord({
+      source: quota.source,
+      plan_name: quota.planName,
+      used_usd: quota.usedUsd,
+      total_spend_usd: quota.totalSpendUsd,
+      bonus_spend_usd: quota.bonusSpendUsd,
+    }),
+    limits: compactRecord({
+      remaining_usd: quota.remainingUsd,
+      limit_usd: quota.limitUsd,
+      used_percent: quota.usedPercent,
+      cursor_models_percent_used: quota.cursorModelsPercentUsed,
+      other_models_percent_used: quota.otherModelsPercentUsed,
+    }),
+  };
+  const sdk = { getAccount: async () => account } as unknown as SdkRuntime;
+  return formatQuota((await readAccount(sdk, "key")) as unknown as AccountPayload);
+}
+
+test("carries adapter output through the account payload into the console quota cell", async () => {
+  expect(await consoleQuotaCell({
+    totalSpend: 3450,
+    includedSpend: 2000,
+    bonusSpend: 1450,
+    limit: 2000,
+    totalPercentUsed: 10,
+  })).toBe("$0.00 / $20.00");
+  expect(await consoleQuotaCell({ totalSpend: 500, apiPercentUsed: 2.1, totalPercentUsed: 1.449 })).toBe("");
 });

--- a/web/src/quota.ts
+++ b/web/src/quota.ts
@@ -1,19 +1,9 @@
 import type { AccountPayload } from "./types.js";
 
-function compactValue(value: unknown): string {
-  if (value == null) return "";
-  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return String(value);
-  if (Array.isArray(value)) return value.map(compactValue).filter(Boolean).join(", ");
-  if (typeof value === "object") {
-    return Object.entries(value as Record<string, unknown>)
-      .slice(0, 4)
-      .map(([key, inner]) => `${key} ${compactValue(inner)}`)
-      .join(" · ");
-  }
-  return "";
-}
-
 function finiteNumber(value: unknown): number | undefined {
+  // Number(null), Number("") and Number(false) are a finite 0 the gateway never reported.
+  if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+  if (typeof value !== "string" || !value.trim()) return undefined;
   const number = Number(value);
   return Number.isFinite(number) ? number : undefined;
 }
@@ -29,10 +19,13 @@ export function formatQuota(account?: AccountPayload): string {
   if (remaining === 0 && limit === 0) return "";
   if (remaining !== undefined && limit !== undefined) return `${usd(remaining)} / ${usd(limit)}`;
   if (remaining !== undefined) return usd(remaining);
+  const used = account.capabilities.spending ? finiteNumber(account.spending?.used_usd) : undefined;
+  const knownLimit = account.capabilities.limits ? limit : undefined;
+  if ([used, knownLimit].every((value) => value === undefined || value === 0)) return "";
   const parts: string[] = [];
-  if (account.capabilities.spending && account.spending) parts.push(compactValue(account.spending));
-  if (account.capabilities.limits && account.limits) parts.push(compactValue(account.limits));
-  return parts.filter(Boolean).join(" · ");
+  if (used !== undefined) parts.push(`${usd(used)} used`);
+  if (knownLimit !== undefined) parts.push(`${usd(knownLimit)} limit`);
+  return parts.join(" / ");
 }
 
 export function formatQuotaBreakdown(account?: AccountPayload): string {

--- a/web/src/quota.ts
+++ b/web/src/quota.ts
@@ -28,12 +28,45 @@ export function formatQuota(account?: AccountPayload): string {
   return parts.join(" / ");
 }
 
+function onDemandSpend(
+  label: string,
+  usedValue: unknown,
+  remainingValue: unknown,
+  limitValue: unknown,
+): string {
+  const used = finiteNumber(usedValue);
+  const remaining = finiteNumber(remainingValue);
+  const limit = finiteNumber(limitValue);
+  // A scope whose reported dollars are all zero is an unconfigured spend limit, not an exhausted budget.
+  if ([used, remaining, limit].every((value) => value === undefined || value === 0)) return "";
+  const values: string[] = [];
+  if (used !== undefined) values.push(`${usd(used)} used`);
+  if (remaining !== undefined) values.push(`${usd(remaining)} remaining`);
+  if (limit !== undefined) values.push(`${usd(limit)} limit`);
+  return `${label} ${values.join(", ")}`;
+}
+
 export function formatQuotaBreakdown(account?: AccountPayload): string {
   if (!account?.capabilities.limits || !account.limits) return "";
   const cursor = finiteNumber(account.limits.cursor_models_percent_used);
   const other = finiteNumber(account.limits.other_models_percent_used);
+  const auto = finiteNumber(account.limits.auto_models_percent_used);
+  const individual = onDemandSpend(
+    "On-demand (individual)",
+    account.limits.on_demand_individual_used,
+    account.limits.on_demand_individual_remaining,
+    account.limits.on_demand_individual_limit,
+  );
+  const pooled = onDemandSpend(
+    "On-demand (pooled)",
+    account.limits.on_demand_pooled_used,
+    account.limits.on_demand_pooled_remaining,
+    account.limits.on_demand_pooled_limit,
+  );
   const parts: string[] = [];
   if (cursor !== undefined) parts.push(`Cursor Models ${cursor.toFixed(1)}%`);
   if (other !== undefined) parts.push(`Other Models ${other.toFixed(1)}%`);
-  return parts.join(" · ");
+  if (auto !== undefined) parts.push(`Auto ${auto.toFixed(1)}%`);
+  parts.push(individual, pooled);
+  return parts.filter(Boolean).join(" · ");
 }


### PR DESCRIPTION
> **Stacked on #21 (`fix/19-quota-remaining-and-used-percent`). Do not merge before it.**
> This branch is based on that PR, not on `main`, so its commit appears in this PR's history until #21 lands. Merged alone, this PR fabricates dollar figures — see "Why it is stacked". Opened as a draft for that reason; I will rebase onto `main` once #21 merges.

Addresses the rendering half of #18. The labelling questions in that issue stay open.

## What this draws

`formatQuotaBreakdown()` now renders `auto_models_percent_used` and the six `on_demand_*` dollar fields (individual/pooled × used/remaining/limit) that `src/sdk/cursor-runtime.ts` already ships to the browser and `web/src/quota.ts` never read — issue #18 §2 ("the Web UI … drops the `auto` value") and §3 ("the Console has no explicit on-demand rendering path").

Zero discipline matches `formatQuota`: a scope whose reported dollars are all zero or absent is an unconfigured spend limit and draws nothing; a configured but unspent scope still draws `$0.00 used`.

## Why it is stacked

Issue #18's "For absent fields" bullet names the root cause: `optionalNumber` uses `Number(value)`, so an upstream `null` becomes a real `0`. That is fixed in #21, not here.

Without it, `{"limitType":"individual","individualLimit":5000,"individualUsed":null,"individualRemaining":null}` renders as `On-demand (individual) $0.00 used, $0.00 remaining, $50.00 limit` — an impossible triple ($0 + $0 ≠ $50) that an operator reads as an exhausted on-demand budget. On top of #21 the same payload renders `Cursor Models 1.0% · Other Models 5.2% · Auto 0.3% · On-demand (individual) $50.00 limit`.

Both outcomes are verified end to end in `tests/sdk/cursor-dashboard.test.ts` — real adapter → `compactRecord` → `readAccount` → formatter, which is issue #18's suggested regression test 3. No local number guard is carried here: once `optionalNumber` is fixed the browser only ever sees a number or an absent key, and the existing `finiteNumber()` handles both.

## Deliberately not done

- **`on_demand_limit_type`** is the one shipped on-demand key left undrawn. Calling a scope "governing" based on an undocumented field is the kind of claim #18's non-goals rule out. Both scopes carry their own labels, satisfying "distinguish individual and pooled on-demand limits", but when both are populated the operator is not told which governs. A contract test asserts that non-coverage explicitly rather than implying it. Happy to mark the scope if you'd prefer — it is a two-line change.
- **`on_demand_spend_usd`** (§3's first field) stays invisible: it lives under `spending`, and `formatQuota()` returns at its `remaining`/`limit` branch before reading `spending`, exactly as §3 describes. That branch belongs to #21 and is untouched here. #18's own expected output draws the per-scope figures rather than the aggregate, so drawing it would print the same dollars twice under two aggregations. The residual gap is on-demand spend on an account with no configured scope.
- **§1/§2 labelling** — the `Quota` direction, and `Cursor Models` on `totalPercentUsed` — is untouched. Note that `Auto` lengthens a lineup §2 argues is already misleading (a total shown beside its own component). `Auto` is the raw field name rather than a pool claim, but the rename belongs in its own change.
- **Localization** (suggested test 5): the three new labels are hardcoded English like the two existing ones. Not fixed, and three strings worse.

## Density

Worst case (both scopes, all three percentages) the breakdown goes 38 → 190 chars, roughly 5 wrapped lines at 12px mono in a ~330px column, on every row of the Accounts and Quota tables. `.quota-breakdown` is `white-space: normal` and `.sub` is `overflow-wrap: anywhere` with no ellipsis, so it wraps rather than clips — but `$2,000.00` can split mid-figure. Typical single-scope case is 121 chars. Only accounts with a configured on-demand limit grow. Left as is: restricting on-demand to `AccountDetailPage` would contradict #18, which names the shared account table as an affected surface.

## Verified

```
npx tsc -p tsconfig.json --noEmit      # clean
npx tsc -p web/tsconfig.json --noEmit  # clean
npx vitest run                         # 31 files, 228 tests (#21's 223 + 5)
bash tests/secret-scan.sh              # no leaks found
```
