### PR TITLE
Refactor durable Cursor SDK run coordination

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -26,9 +26,9 @@ BF Labs UI, Copyright (c) 2026 BF Labs, used under the MIT License. The copied s
 maintained in this repository so the standalone gateway does not require a private package
 registry at runtime or build time.
 
-## Known production audit findings (2026-08-15)
+## Known production audit findings (2026-08-28)
 
-`npm audit --omit=dev` on `@cursor/sdk@1.0.28`:
+`npm audit --omit=dev` on `@cursor/sdk@1.0.30`:
 
 | Package | Severity | Notes |
 |---|---|---|
@@ -36,4 +36,4 @@ registry at runtime or build time.
 | `@connectrpc/connect-node` | moderate | Depends on the vulnerable `undici` range. `fixAvailable: false`. |
 | `@cursor/sdk` | moderate | Depends on `@connectrpc/connect-node`. `fixAvailable: false`. |
 
-These are accepted SDK-tree risks for v0.1. Do not run `npm audit fix --force`. Re-check on the next exact SDK pin.
+These are accepted SDK-tree risks for the current exact SDK pin. Do not run `npm audit fix --force`. Re-check on the next exact SDK pin.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,6 +9,7 @@ HTTP /v1/messages | /v1/chat/completions | /v1/responses
   -> protocol parse (Chat/Responses convert to canonical ParsedMessages)
   -> CursorAgentTurn (protocol-neutral ordinary-turn IR)
   -> RunCoordinator
+       -> SdkRunDriver (the only create/resume/send/pump wiring)
        -> tool_result: existing ATTACH / lineage resume / transcript recovery
        -> exact successor: Agent.resume/send(current turn text+images only)
        -> unknown/fork/compact: cold rebuild with full transcript fallback
@@ -48,11 +49,11 @@ Pending calls live in a `Map<toolUseId, PendingCall>`. There is no single-pendin
 
 ## Restart
 
-SDK Agent history lives in credential-partitioned `$STATE_DIR/sdk-store/<fingerprint>` directories via the official `JsonlLocalAgentStore`. Each credential also receives a private empty-workspace partition. Gateway lineage (`$STATE_DIR/lineage`) keeps only resume metadata: session id, SDK agent id, credential fingerprint, model and explicit model parameters, state, pending tool ids, optional result digest, and timestamps.
+SDK Agent history lives in credential-partitioned `$STATE_DIR/sdk-store/<fingerprint>` directories via the official `JsonlLocalAgentStore`. Each credential also receives a private empty-workspace partition. Gateway lineage (`$STATE_DIR/lineage`) keeps only resume metadata: session id, SDK agent id, credential fingerprint, model and explicit model parameters, canonical session-policy and executable-tool-catalog digests, state, pending tool ids, optional result digest, and timestamps. Lineage schema v2 fails closed and quarantines older/incomplete records instead of silently resuming them.
 
 Ordinary multi-turn requests without `x-cursor-session-id` use a credential-free journal of digests (`STATE_DIR/ordinary-turns.json`). Exact linear successors reuse the same Agent and `send()` only the latest user text/images. Forks, compact/missing anchors, model/effort/tool-catalog mismatches, and credential rotation cold-rebuild. Identical request digests replay in-process; after a process restart they fail closed because assistant bodies are not persisted.
 
-Completed follow-up with `x-cursor-session-id` looks up lineage, checks fingerprint/model, then `Agent.resume` + `send` on that same store. `ORDINARY_TURN_COORDINATOR=0` restores the previous flatten-every-turn path. Pending callback Promises are not serialized; the lineage stores only tool ids and names. After owner death, an exact credential/model/tool-id batch resumes the persisted Agent and sends a synthetic host-recovery turn with `local.force=true`. Concurrent duplicate-same recovery is singleflight. Assistant replay bodies are not persisted, so duplicate-same after a later process restart still has no persisted response body.
+Completed follow-up with `x-cursor-session-id` looks up lineage, checks credential/model/session policy, then `Agent.resume` + `send` on that same store. `ORDINARY_TURN_COORDINATOR=0` restores the previous flatten-every-turn path. Pending callback Promises are not serialized; the lineage stores only tool ids, names, and policy digests. After owner death, an exact credential/model/tool-catalog/tool-id batch resumes the persisted Agent and sends a synthetic host-recovery turn with `local.force=true`. Concurrent duplicate-same recovery is singleflight. Assistant replay bodies are not persisted, so duplicate-same after a later process restart still has no persisted response body.
 
 When no exact live or persisted owner can attach, tool continuation may cold-branch only from a self-contained transcript. The latest assistant tool batch must exactly match the submitted result ids and every call must exist in the request catalog. Historical completed calls are indexed by stable tool-name/input signature; if the recovered Harness requests one again, the gateway returns the recorded result internally rather than exposing the same side effect to the client twice. Identical recovery requests are singleflight and replayable for the normal replay TTL.
 
@@ -62,4 +63,4 @@ Before any semantic response is emitted, a generic SDK authentication-session fa
 
 Production uses `createCursorRuntime({ stateDir })` and passes the matching credential-partitioned `JsonlLocalAgentStore` and workspace to every `Agent.create` and `Agent.resume`. Tests inject `FakeSdk`. The HTTP layer never imports `@cursor/sdk` directly except through that adapter.
 
-Gateway lineage is a separate JSON file store under `STATE_DIR/lineage`. It recovers **completed** Agent ids only. Pending tool callbacks are not serialized.
+Gateway lineage is a separate JSON file store under `STATE_DIR/lineage`. It recovers completed Agent ids and exact pending-tool metadata; pending callback Promises themselves are never serialized.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,6 +28,8 @@ Text/thinking streaming uses official `SendOptions.onDelta` (`text-delta` / `thi
 
 `customTool.execute` is the authority for client-visible `tool_use`. SDK `tool_call` stream events are diagnostic and are de-duplicated by call id.
 
+`SdkRunDriver` maps one custom-tool table before Agent create/resume and carries that same table through `send()` and EventPump attachment. Tool callbacks that fire synchronously during Agent resume or send are queued on the Session and drained only after the pump is attached; the coordinator never remaps tools or calls `Agent.resume` directly.
+
 ## Network transport
 
 Direct local SDK runs retain the official HTTP/2 transport. Node does not apply

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -86,7 +86,7 @@ Set `STATE_DIR` for:
 
 Host / local-dev default (no `STATE_DIR`) is a process temp path: `$TMPDIR/cursor-sdk2api/state`. The container **image** and `docker-compose.yml` default `STATE_DIR` to `/data` and compose declares a named volume. A bare `docker run` without `-e STATE_DIR` still gets `/data` from the image `ENV`.
 
-Lineage stores only session id, SDK agent id, credential fingerprint, model and explicit model parameters, state, pending tool ids and names, optional result digest, and timestamps. It does not store API keys, prompts, tool args, or tool results. Pending tool results can resume the persisted SDK Agent after restart when the client resends the exact tool catalog and pending id batch. Assistant replay bodies are **not** persisted, so duplicate-same replay after a later restart is still unavailable.
+Lineage schema v2 stores only session id, SDK agent id, credential fingerprint, model and explicit model parameters, canonical session-policy and executable-tool-catalog digests, state, pending tool ids and names, optional result digest, and timestamps. It does not store API keys, prompts, tool schemas/args/results, or assistant bodies. Older/incomplete lineage is quarantined and fails closed. Pending tool results can resume the persisted SDK Agent after restart when the client resends the exact tool catalog and pending id batch. Assistant replay bodies are **not** persisted, so duplicate-same replay after a later restart is still unavailable.
 
 Session/registry TTL and the periodic sweep share the same clock. Completed and recoverable pending lineage expire with `SESSION_TTL_MS` (default 30 minutes), then they are deleted. Graceful shutdown does not delete recoverable lineage.
 
@@ -107,7 +107,7 @@ In-process SDK Run handles and pending tool Promises cannot move to another proc
 1. Stop sending new sessions to the old instance (`SIGTERM` starts drain).
 2. Keep routing existing tool-result traffic to the same instance (sticky ownership).
 3. Wait until active sessions reach zero or the drain deadline.
-4. Then replace the process. Completed lineage under `STATE_DIR` survives; pending tool turns do not.
+4. Then replace the process. Completed lineage and exact pending-tool metadata under `STATE_DIR` survive; live callback Promises do not. A restarted owner resumes the persisted Agent with the validated result batch rather than reusing the lost Promise.
 
 A replica without the original live handle first tries persisted lineage. If that is unavailable, it may cold-branch only from a complete transcript with an exact latest tool batch; otherwise it returns `409 cursor_session_lost` rather than an empty success.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -33,6 +33,6 @@ separately protected environment secret.
 - Duplicate different tool results fail closed to avoid a second side effect.
 - After restart, pending continuations prefer persisted SDK Agent lineage with an exact credential, model, tool catalog, and pending tool-id batch. A cold branch is allowed only when the client supplies a complete transcript whose latest assistant tool batch exactly matches the submitted results; otherwise it fails closed.
 - Cold recovery never blindly re-executes a completed external tool. Historical results are replayed only for the same stable tool-name/input signature, in transcript order; genuinely new calls still return to the client.
-- Completed resume is bound to credential fingerprint + model. Mismatch is `409 cursor_session_conflict`.
+- Completed resume is bound to credential fingerprint + canonical model/tool/session policy. Mismatch is `409 cursor_session_conflict`.
 - Gateway lineage files are owner-only (`0700`/`0600`) and contain only resume metadata, including non-secret model parameters; they omit API keys, prompts, system text, tool schemas/args/results, and assistant replay bodies. Corrupt records are quarantined and ignored. Optional `lastResultDigest` is a hash, not a payload.
 - `STATE_DIR` is sensitive local state: lineage metadata plus the official SDK store (conversation/checkpoint payloads). Treat it as owner-only. Prefer an encrypted volume and `0700` access; do not share or backup the directory as if it were anonymous cache.

--- a/docs/evidence/2026-08-28-cursor-sdk-1.0.30-audit.md
+++ b/docs/evidence/2026-08-28-cursor-sdk-1.0.30-audit.md
@@ -1,0 +1,29 @@
+# `@cursor/sdk` 1.0.30 compatibility audit
+
+Scope: exact dependency update from 1.0.28 to 1.0.30. This is a package and
+contract-test audit, not a live Cursor model receipt.
+
+## Public surface delta
+
+- 1.0.29 adds optional `SDKCustomTool.outputSchema`. The SDK advertises it
+  verbatim when supplied and does not validate tool results against it.
+- The cloud-only `V1Agent.status` type adds `IDLE`.
+- 1.0.30 does not add another public declaration change. It updates packaged
+  runtime artifacts and adds the internal `anysphere-source` export condition.
+- The local gateway surfaces it uses remain compatible: `Agent.create`,
+  `Agent.resume`, `SDKAgent.send`, `Run.stream`, `Run.wait`, `Run.cancel`,
+  `Cursor.models.list`, and `Cursor.me`.
+
+## `outputSchema` decision
+
+No gateway mapping is added. Anthropic Messages tools and OpenAI Chat or
+Responses function tools accepted by this gateway carry an input JSON Schema,
+but none of the current protocol IRs carries an MCP output schema. Inventing or
+inferring one would not round-trip losslessly and would change tool fingerprints
+without a public input contract. The SDK field therefore remains omitted.
+
+## Verification boundary
+
+The deterministic suite, TypeScript checks, server and console builds, package
+lock readback, dependency audit, diff check, and secret scan cover this update.
+Live Cursor credentials and model behavior are outside this audit.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "cursor-sdk2api",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cursor-sdk2api",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@cursor/sdk": "1.0.28",
+        "@cursor/sdk": "1.0.30",
         "proxy-agent": "8.0.2",
         "undici": "8.10.0"
       },
@@ -85,9 +85,9 @@
       }
     },
     "node_modules/@cursor/sdk": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk/-/sdk-1.0.28.tgz",
-      "integrity": "sha512-bO7Ld00xXV5kFB9WDeBiyADgon3r/BQXc9qZ4sHlXX9ZQpzIkTfHrYU7g278pcHTuz+l/vPcPcc7JByeRWHeqA==",
+      "version": "1.0.30",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk/-/sdk-1.0.30.tgz",
+      "integrity": "sha512-s3gIXfTD3w8ys+KFE81JjjoiJcynkHsf/JCDyXrnbliIac3dkT59hwYZII3XhsT1DlXIfqg+YzSMru6w1CkZow==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@bufbuild/protobuf": "1.10.0",
@@ -101,17 +101,17 @@
         "node": ">=22.13"
       },
       "optionalDependencies": {
-        "@cursor/sdk-darwin-arm64": "1.0.28",
-        "@cursor/sdk-darwin-x64": "1.0.28",
-        "@cursor/sdk-linux-arm64": "1.0.28",
-        "@cursor/sdk-linux-x64": "1.0.28",
-        "@cursor/sdk-win32-x64": "1.0.28"
+        "@cursor/sdk-darwin-arm64": "1.0.30",
+        "@cursor/sdk-darwin-x64": "1.0.30",
+        "@cursor/sdk-linux-arm64": "1.0.30",
+        "@cursor/sdk-linux-x64": "1.0.30",
+        "@cursor/sdk-win32-x64": "1.0.30"
       }
     },
     "node_modules/@cursor/sdk-darwin-arm64": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-arm64/-/sdk-darwin-arm64-1.0.28.tgz",
-      "integrity": "sha512-P9k17dHzyYirjvMIkdxGtIWFEpkC1lB0TSbNE3AEusr5UwYTHFt13+MK5j9GK8Tg3r9ncg4IeSDQgx7HvA2VAw==",
+      "version": "1.0.30",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-arm64/-/sdk-darwin-arm64-1.0.30.tgz",
+      "integrity": "sha512-O0w2fLd6jxrvAUOJGsKBs8VSi5OojqqEOMFBzHTHS82wU/DX3ZlizK3czzCXxDKs3l8j/BVQwVCxP9jMFcf41Q==",
       "cpu": [
         "arm64"
       ],
@@ -125,9 +125,9 @@
       }
     },
     "node_modules/@cursor/sdk-darwin-x64": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-x64/-/sdk-darwin-x64-1.0.28.tgz",
-      "integrity": "sha512-SFamp6b3a5/Og4RIYpxivA9TNqSam8+yeDwdu4+iV9GwZygtw2y1r8Qz2r7VpDj40gou2UP/p8Nu54nAdAl4Mg==",
+      "version": "1.0.30",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-x64/-/sdk-darwin-x64-1.0.30.tgz",
+      "integrity": "sha512-TdjreV7V6gtSKbUaXDarfE1735PES6uzLgLxp42E5kT6EXpjQhKsifdsYOMdsO/RBw166kya/XxG24L/FUfEHA==",
       "cpu": [
         "x64"
       ],
@@ -141,9 +141,9 @@
       }
     },
     "node_modules/@cursor/sdk-linux-arm64": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-arm64/-/sdk-linux-arm64-1.0.28.tgz",
-      "integrity": "sha512-J0Pp2vZLApRm4+j35zNFaMkAuI7AoTzY7bt1UdRC/NSAcJsh74soCf/HqB59Ps94HaznF7PYl1ft6ltnn4to4g==",
+      "version": "1.0.30",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-arm64/-/sdk-linux-arm64-1.0.30.tgz",
+      "integrity": "sha512-1+bsmri6vJ2YuqL/SQ6QSx/ymu2eBzjGgT1bTgN47tCzxDgNOKacXtghpx4zdHM5AmOtT+aLXVVxXjStXmNtcA==",
       "cpu": [
         "arm64"
       ],
@@ -157,9 +157,9 @@
       }
     },
     "node_modules/@cursor/sdk-linux-x64": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-x64/-/sdk-linux-x64-1.0.28.tgz",
-      "integrity": "sha512-YFBA2syvFJZE15d1MBtgqJJCuYGbZEU7GcE8EaGDU3A6iJguZg7PB97c3ux2qN5kJtdk0+EveevrIi2UJsr5Ag==",
+      "version": "1.0.30",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-x64/-/sdk-linux-x64-1.0.30.tgz",
+      "integrity": "sha512-5TRAM1xNwVr0Lox2ay5U5h+VY1OeqJLgnS28da7mx+ZkmeAU+hzuUFq2/lcIqoJrp2qBRdUH5WzI44JNtjBKmg==",
       "cpu": [
         "x64"
       ],
@@ -173,9 +173,9 @@
       }
     },
     "node_modules/@cursor/sdk-win32-x64": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-win32-x64/-/sdk-win32-x64-1.0.28.tgz",
-      "integrity": "sha512-+9G30RcR+cDkQxiyFBfrNWSBkZJc19G9L7+bTl9PdiBI7FPCu1vCCdP4BBvntdCkFS9LwEX3iJyWJqEreFjNQg==",
+      "version": "1.0.30",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-win32-x64/-/sdk-win32-x64-1.0.30.tgz",
+      "integrity": "sha512-kVjpWmLTFLL131TQm3ytz1HbAeyjBRAHMtr6vyLtbBMuLBb0la5igvt58Xi8mXwekymWXim1+rZj7ZYUO3K1rw==",
       "cpu": [
         "x64"
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cursor-sdk2api",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cursor-sdk2api",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@cursor/sdk": "1.0.30",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "secret:scan": "bash tests/secret-scan.sh"
   },
   "dependencies": {
-    "@cursor/sdk": "1.0.28",
+    "@cursor/sdk": "1.0.30",
     "proxy-agent": "8.0.2",
     "undici": "8.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor-sdk2api",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Independent MIT gateway that exposes official @cursor/sdk as Anthropic- and OpenAI-compatible HTTP APIs.",
   "license": "MIT",
   "type": "module",

--- a/src/config.ts
+++ b/src/config.ts
@@ -119,7 +119,7 @@ export function loadConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfi
     gatewayAccessKey: process.env.GATEWAY_ACCESS_KEY || undefined,
     instanceId: instanceId(process.env.INSTANCE_ID),
     version: process.env.GATEWAY_VERSION?.trim() || "0.1.0",
-    sdkVersion: "1.0.28",
+    sdkVersion: "1.0.30",
     globalActiveRuns: envInt("GLOBAL_ACTIVE_RUNS", 4),
     perCredentialActiveRuns: envInt("PER_CREDENTIAL_ACTIVE_RUNS", 2),
     maxAwaitingSessions: envInt("MAX_AWAITING_SESSIONS", 32),

--- a/src/core/cursor-agent-turn.ts
+++ b/src/core/cursor-agent-turn.ts
@@ -7,6 +7,10 @@ import type {
   ParsedMessages,
 } from "../protocols/anthropic/types.js";
 import type { ToolChoicePolicy } from "../protocols/tool-choice.js";
+import {
+  normalizeModelParams,
+  sessionPolicyFingerprintFromParsed,
+} from "./session-policy.js";
 
 export const CURSOR_AGENT_TURN_VERSION = 1;
 export const CURSOR_AGENT_ROUTE = "cursor-agent";
@@ -34,6 +38,7 @@ export interface CursorAgentTurn {
     parentAssistantAnchor: string;
     turnIndex: number;
     toolCatalogDigest: string;
+    sessionPolicyFingerprint: string;
   };
 }
 
@@ -41,7 +46,7 @@ export function effectiveCursorModel(
   model: string,
   modelParams: Array<{ id: string; value: string }>,
 ): string {
-  return `${model}|${stableStringify(modelParams)}`;
+  return `${model}|${stableStringify(normalizeModelParams(modelParams))}`;
 }
 
 export function serializedContent(content: unknown): string {
@@ -207,6 +212,7 @@ export function cursorAgentTurnFromParsed(
       parentAssistantAnchor: parent ? digestAssistantAnchor(parent.content) : "",
       turnIndex,
       toolCatalogDigest,
+      sessionPolicyFingerprint: sessionPolicyFingerprintFromParsed(parsed),
     },
   };
   turn.lineage.requestDigest = digestCursorAgentTurnRequest(turn);

--- a/src/core/cursor-agent-turn.ts
+++ b/src/core/cursor-agent-turn.ts
@@ -36,6 +36,7 @@ export interface CursorAgentTurn {
   lineage: {
     requestDigest: string;
     parentAssistantAnchor: string;
+    historyDigest: string;
     turnIndex: number;
     toolCatalogDigest: string;
     sessionPolicyFingerprint: string;
@@ -74,7 +75,76 @@ export function serializedContent(content: unknown): string {
 }
 
 export function digestAssistantAnchor(content: unknown): string {
-  return sha256Hex(serializedContent(content));
+  return digestJson(canonicalContent(content));
+}
+
+function canonicalContent(content: unknown): unknown[] {
+  if (typeof content === "string") return [{ type: "text", text: content }];
+  if (!Array.isArray(content)) return [];
+  return content.map((value) => {
+    if (!value || typeof value !== "object") return { type: "unknown" };
+    const block = value as AnthropicContentBlock;
+    if (block.type === "text") return { type: "text", text: block.text };
+    if (block.type === "thinking") {
+      return {
+        type: "thinking",
+        thinking: block.thinking,
+        signature: block.signature ?? "",
+      };
+    }
+    if (block.type === "tool_use") {
+      return {
+        type: "tool_use",
+        id: block.id,
+        name: block.name,
+        input: block.input ?? null,
+        toolKind: block.tool_kind ?? "function",
+        namespace: block.namespace ?? "",
+      };
+    }
+    if (block.type === "tool_result") {
+      return {
+        type: "tool_result",
+        toolUseId: block.tool_use_id,
+        content: block.content ?? null,
+        isError: Boolean(block.is_error),
+      };
+    }
+    if (block.type === "image") {
+      const source = block.source;
+      return source.type === "base64"
+        ? {
+            type: "image",
+            sourceType: "base64",
+            mediaType: source.media_type,
+            digest: sha256Hex(source.data),
+          }
+        : { type: "image", sourceType: "url", digest: sha256Hex(source.url) };
+    }
+    return { type: "unknown" };
+  });
+}
+
+function advanceHistoryDigest(
+  previous: string,
+  role: AnthropicMessage["role"],
+  contentDigest: string,
+): string {
+  return digestJson({ previous, role, contentDigest });
+}
+
+function historyDigestBeforeCurrentUser(
+  system: string,
+  conversation: AnthropicMessage[],
+  userIndex: number,
+): string {
+  let digest = digestJson({ system });
+  for (let index = 0; index < userIndex; index += 1) {
+    const message = conversation[index];
+    if (!message) continue;
+    digest = advanceHistoryDigest(digest, message.role, digestAssistantAnchor(message.content));
+  }
+  return digest;
 }
 
 export function normalizeTools(tools: AnthropicTool[] | undefined): AnthropicTool[] {
@@ -152,6 +222,8 @@ export function digestCursorAgentTurnRequest(turn: CursorAgentTurn): string {
     toolCatalogDigest: turn.lineage.toolCatalogDigest,
     toolChoice: turn.toolChoice,
     parentAssistantAnchor: turn.lineage.parentAssistantAnchor,
+    historyDigest: turn.lineage.historyDigest,
+    sessionPolicyFingerprint: turn.lineage.sessionPolicyFingerprint,
     turnIndex: turn.lineage.turnIndex,
   });
 }
@@ -163,20 +235,30 @@ export function cursorAgentTurnLineageKey(turn: CursorAgentTurn): string {
     channelId: turn.channelId,
     effectiveModel: turn.effectiveModel,
     parentAssistantAnchor: turn.lineage.parentAssistantAnchor,
+    historyDigest: turn.lineage.historyDigest,
     turnIndex: turn.lineage.turnIndex,
     toolCatalogDigest: turn.lineage.toolCatalogDigest,
+    sessionPolicyFingerprint: turn.lineage.sessionPolicyFingerprint,
   });
 }
 
 export function nextCursorAgentTurnLineageKey(turn: CursorAgentTurn, assistantAnchor: string): string {
+  const historyAfterUser = advanceHistoryDigest(
+    turn.lineage.historyDigest,
+    "user",
+    digestAssistantAnchor(turn.conversation[lastUserIndex(turn.conversation)]?.content),
+  );
+  const historyAfterAssistant = advanceHistoryDigest(historyAfterUser, "assistant", assistantAnchor);
   return digestJson({
     tenantScope: turn.tenantScope,
     route: turn.route,
     channelId: turn.channelId,
     effectiveModel: turn.effectiveModel,
     parentAssistantAnchor: assistantAnchor,
+    historyDigest: historyAfterAssistant,
     turnIndex: turn.lineage.turnIndex + 1,
     toolCatalogDigest: turn.lineage.toolCatalogDigest,
+    sessionPolicyFingerprint: turn.lineage.sessionPolicyFingerprint,
   });
 }
 
@@ -210,6 +292,7 @@ export function cursorAgentTurnFromParsed(
     lineage: {
       requestDigest: "",
       parentAssistantAnchor: parent ? digestAssistantAnchor(parent.content) : "",
+      historyDigest: historyDigestBeforeCurrentUser(parsed.systemText, conversation, userIndex),
       turnIndex,
       toolCatalogDigest,
       sessionPolicyFingerprint: sessionPolicyFingerprintFromParsed(parsed),

--- a/src/core/lineage-store.ts
+++ b/src/core/lineage-store.ts
@@ -5,12 +5,14 @@ import type { Clock } from "../clock.js";
 export type LineageState = "completed" | "awaiting_tool_results" | "failed";
 
 export interface LineageRecord {
-  version: 1;
+  version: 2;
   sessionId: string;
   sdkAgentId: string;
   credentialFingerprint: string;
   modelId: string;
   modelParams?: Array<{ id: string; value: string }>;
+  sessionPolicyFingerprint: string;
+  executableToolCatalogFingerprint: string;
   state: LineageState;
   pendingToolIds: string[];
   pendingCalls?: Array<{ toolUseId: string; name: string }>;
@@ -174,11 +176,23 @@ export class LineageStore {
 function isLineageRecord(value: unknown): value is LineageRecord {
   if (!value || typeof value !== "object") return false;
   const record = value as Record<string, unknown>;
-  if (record.version !== 1) return false;
+  if (record.version !== 2) return false;
   if (typeof record.sessionId !== "string" || !SESSION_ID_RE.test(record.sessionId)) return false;
   if (typeof record.sdkAgentId !== "string" || !record.sdkAgentId) return false;
   if (typeof record.credentialFingerprint !== "string" || !record.credentialFingerprint) return false;
   if (typeof record.modelId !== "string" || !record.modelId) return false;
+  if (
+    typeof record.sessionPolicyFingerprint !== "string" ||
+    !/^[a-f0-9]{64}$/.test(record.sessionPolicyFingerprint)
+  ) {
+    return false;
+  }
+  if (
+    typeof record.executableToolCatalogFingerprint !== "string" ||
+    !/^[a-f0-9]{64}$/.test(record.executableToolCatalogFingerprint)
+  ) {
+    return false;
+  }
   if (
     record.modelParams !== undefined &&
     (!Array.isArray(record.modelParams) ||

--- a/src/core/ordinary-turn-journal.ts
+++ b/src/core/ordinary-turn-journal.ts
@@ -16,6 +16,7 @@ export interface OrdinaryTurnRecord {
   parentAssistantAnchor: string;
   turnIndex: number;
   toolCatalogDigest: string;
+  sessionPolicyFingerprint?: string;
   assistantAnchor: string;
   agentId: string;
   credentialFingerprint: string;
@@ -50,6 +51,12 @@ function validateRecord(record: OrdinaryTurnRecord): void {
   }
   if (!record.lineageKey || !record.requestDigest || !record.effectiveModel) {
     throw new Error("incomplete Cursor ordinary-turn record");
+  }
+  if (
+    record.sessionPolicyFingerprint !== undefined &&
+    !/^[a-f0-9]{64}$/.test(record.sessionPolicyFingerprint)
+  ) {
+    throw new Error("invalid Cursor ordinary-turn session policy fingerprint");
   }
   if (record.tenantScope && !/^[a-f0-9]{64}$/.test(record.tenantScope)) {
     throw new Error("invalid Cursor ordinary-turn tenant scope");

--- a/src/core/ordinary-turn.ts
+++ b/src/core/ordinary-turn.ts
@@ -95,6 +95,7 @@ export function decideOrdinaryTurn(input: {
       parent.tenantScope !== turn.tenantScope ||
       parent.effectiveModel !== turn.effectiveModel ||
       parent.toolCatalogDigest !== turn.lineage.toolCatalogDigest ||
+      parent.sessionPolicyFingerprint !== turn.lineage.sessionPolicyFingerprint ||
       Number(parent.channelId || 0) !== Number(turn.channelId || 0)
     ) {
       return { action: "rebuild", reason: "lineage_mismatch", record: parent };

--- a/src/core/ordinary-turn.ts
+++ b/src/core/ordinary-turn.ts
@@ -57,6 +57,12 @@ export function decideOrdinaryTurn(input: {
   }
 
   const exact = journal.findExact(lineageKey, requestDigest);
+  if (
+    exact &&
+    exact.sessionPolicyFingerprint !== turn.lineage.sessionPolicyFingerprint
+  ) {
+    return { action: "rebuild", reason: "lineage_mismatch", record: exact };
+  }
   if (exact?.state === "completed") {
     if (hasReplay) return { action: "replay", reason: "identical_digest", record: exact };
     return { action: "fail_closed", reason: "completed_without_in_memory_response", record: exact };

--- a/src/core/run-coordinator.ts
+++ b/src/core/run-coordinator.ts
@@ -16,7 +16,7 @@ import type { Logger } from "../log.js";
 import type { ParsedMessages, ParsedToolResult } from "../protocols/anthropic/types.js";
 import { renderPrompt } from "../protocols/anthropic/parse.js";
 import { createAnthropicWriter } from "../protocols/anthropic/writer.js";
-import type { SdkDeltaUpdate, SdkRuntime } from "../sdk/port.js";
+import type { SdkRuntime } from "../sdk/port.js";
 import {
   currentTurnSendPayload,
   cursorAgentTurnFromParsed,
@@ -31,6 +31,7 @@ import { decideOrdinaryTurn } from "./ordinary-turn.js";
 import type { OrdinaryTurnJournal, OrdinaryTurnRecord } from "./ordinary-turn-journal.js";
 import { Session } from "./session.js";
 import { SessionRegistry } from "./session-registry.js";
+import { SdkRunDriver } from "./sdk-run-driver.js";
 import { batchDigest, mapClientTools } from "./tool-bridge.js";
 import { buildTranscriptRecovery } from "./transcript-recovery.js";
 import type { LineageRecord, LineageStore } from "./lineage-store.js";
@@ -71,29 +72,6 @@ function sameModelParams(
   return left.every((item, index) => item.id === right[index]?.id && item.value === right[index]?.value);
 }
 
-function createDeltaBridge() {
-  const early: SdkDeltaUpdate[] = [];
-  let pump: EventPump | undefined;
-  const ingest = (update: SdkDeltaUpdate) => {
-    early.push(update);
-    flush();
-  };
-  const flush = () => {
-    if (!pump) return;
-    while (early.length > 0) {
-      const next = early.shift();
-      if (next) pump.ingestDelta(next);
-    }
-  };
-  return {
-    ingest,
-    attach(next: EventPump) {
-      pump = next;
-      flush();
-    },
-  };
-}
-
 export class RunCoordinator {
   private readonly pendingRecoveries = new Map<
     string,
@@ -105,8 +83,15 @@ export class RunCoordinator {
   >();
   private readonly ordinaryInflight = new Map<string, Promise<void>>();
   private readonly ordinaryReplay = new Map<string, OrdinaryReplayEntry>();
+  private readonly sdkRunDriver: SdkRunDriver;
 
   constructor(private readonly deps: CoordinatorDeps) {
+    this.sdkRunDriver = new SdkRunDriver({
+      sdk: deps.sdk,
+      clock: deps.clock,
+      toolBatchSettleMs: deps.config.toolBatchSettleMs,
+      firstEventTimeoutMs: deps.config.firstEventTimeoutMs,
+    });
     this.deps.ordinaryJournal?.setOnExpire((record) => {
       const session = this.findSessionByAgentId(record.agentId);
       if (session) this.deps.registry.forget(session, "ordinary_turn_expired");
@@ -547,38 +532,15 @@ export class RunCoordinator {
       modelParams: parsed.modelParams,
     });
     if (ordinaryTurn) session.ordinaryTurn = ordinaryTurn;
-    const customTools = mapClientTools(parsed.tools, session, this.deps.clock, () => undefined);
     try {
-      const agent = await this.deps.sdk.createAgent({
-        apiKey: auth.cursorApiKey,
-        modelId: parsed.model,
-        modelParams: session.modelParams,
-        workspaceDir: this.deps.workspaceDir,
-        clientToolNames: parsed.tools.map((tool) => tool.name),
-        customTools,
-      });
-      session.agent = agent;
-      session.sdkAgentId = agent.agentId;
-      session.state = "running";
       const prompt = sendOverride ?? renderPrompt(parsed);
-      const deltas = createDeltaBridge();
-      const run = await agent.send({
-        text: prompt.text,
-        images: prompt.images,
-        customTools,
-        onDelta: deltas.ingest,
-      });
-      session.run = run;
-      const pump = new EventPump(
+      const pump = await this.sdkRunDriver.start({
         session,
-        run,
-        this.deps.clock,
-        this.deps.config.toolBatchSettleMs,
-        this.deps.config.firstEventTimeoutMs,
-      );
-      session.pump = pump;
-      deltas.attach(pump);
-      pump.ingestEarly(session.earlyCalls.splice(0));
+        tools: parsed.tools,
+        agent: { type: "create", apiKey: auth.cursorApiKey, workspaceDir: this.deps.workspaceDir },
+        send: prompt,
+      });
+      session.state = "running";
       await this.drive(req, res, session, pump, parsed.stream, requestId, writerFactory);
     } catch (error) {
       if (!res.headersSent && session.state !== "awaiting_tool_results") {
@@ -618,26 +580,14 @@ export class RunCoordinator {
     session.lastResultDigest = undefined;
     session.replay = undefined;
     session.appliedBoundaryId = undefined;
-    const customTools = mapClientTools(parsed.tools, session, this.deps.clock, () => undefined);
     const prompt = sendOverride ?? renderPrompt(parsed);
-    const deltas = createDeltaBridge();
     try {
-      const run = await session.agent.send({
-        text: prompt.text,
-        images: prompt.images,
-        customTools,
-        onDelta: deltas.ingest,
-      });
-      session.run = run;
-      const pump = new EventPump(
+      const pump = await this.sdkRunDriver.start({
         session,
-        run,
-        this.deps.clock,
-        this.deps.config.toolBatchSettleMs,
-        this.deps.config.firstEventTimeoutMs,
-      );
-      session.pump = pump;
-      deltas.attach(pump);
+        tools: parsed.tools,
+        agent: { type: "existing", agent: session.agent },
+        send: prompt,
+      });
       await this.drive(req, res, session, pump, parsed.stream, requestId, writerFactory);
     } catch (error) {
       if (!res.headersSent) this.deps.registry.forget(session, "follow_up_failed");
@@ -817,43 +767,15 @@ export class RunCoordinator {
       modelParams: parsed.modelParams,
     });
     session.lastResultDigest = batchDigest(results);
-    const customTools = mapClientTools(
-      parsed.tools,
-      session,
-      this.deps.clock,
-      () => undefined,
-      recovery.completedResults,
-    );
-    const deltas = createDeltaBridge();
     try {
-      const agent = await this.deps.sdk.createAgent({
-        apiKey: auth.cursorApiKey,
-        modelId: parsed.model,
-        modelParams: session.modelParams,
-        workspaceDir: this.deps.workspaceDir,
-        clientToolNames: parsed.tools.map((tool) => tool.name),
-        customTools,
-      });
-      session.agent = agent;
-      session.sdkAgentId = agent.agentId;
-      session.state = "running";
-      const run = await agent.send({
-        text: recovery.prompt,
-        images: parsed.images,
-        customTools,
-        onDelta: deltas.ingest,
-      });
-      session.run = run;
-      const pump = new EventPump(
+      const pump = await this.sdkRunDriver.start({
         session,
-        run,
-        this.deps.clock,
-        this.deps.config.toolBatchSettleMs,
-        this.deps.config.firstEventTimeoutMs,
-      );
-      session.pump = pump;
-      deltas.attach(pump);
-      pump.ingestEarly(session.earlyCalls.splice(0));
+        tools: parsed.tools,
+        agent: { type: "create", apiKey: auth.cursorApiKey, workspaceDir: this.deps.workspaceDir },
+        send: { text: recovery.prompt, images: parsed.images },
+        completedResults: recovery.completedResults,
+      });
+      session.state = "running";
       return { session, pump };
     } catch (error) {
       this.deps.registry.forget(session, "transcript_recovery_failed");
@@ -936,37 +858,18 @@ export class RunCoordinator {
     session.lastResultDigest = digest;
     this.deps.registry.adopt(session);
 
-    const customTools = mapClientTools(parsed.tools, session, this.deps.clock, () => undefined);
-    const deltas = createDeltaBridge();
     try {
-      const agent = await this.deps.sdk.resumeAgent({
-        agentId: record.sdkAgentId,
-        apiKey: auth.cursorApiKey,
-        modelId: parsed.model,
-        modelParams: session.modelParams,
-        workspaceDir: this.deps.workspaceDir,
-        clientToolNames: parsed.tools.map((tool) => tool.name),
-        customTools,
-      });
-      session.agent = agent;
-      session.sdkAgentId = record.sdkAgentId;
-      const run = await agent.send({
-        text: recoveredToolResultPrompt(record, results),
-        customTools,
-        force: true,
-        onDelta: deltas.ingest,
-      });
-      session.run = run;
-      const pump = new EventPump(
+      const pump = await this.sdkRunDriver.start({
         session,
-        run,
-        this.deps.clock,
-        this.deps.config.toolBatchSettleMs,
-        this.deps.config.firstEventTimeoutMs,
-      );
-      session.pump = pump;
-      deltas.attach(pump);
-      pump.ingestEarly(session.earlyCalls.splice(0));
+        tools: parsed.tools,
+        agent: {
+          type: "resume",
+          agentId: record.sdkAgentId,
+          apiKey: auth.cursorApiKey,
+          workspaceDir: this.deps.workspaceDir,
+        },
+        send: { text: recoveredToolResultPrompt(record, results), force: true },
+      });
       for (const id of record.pendingToolIds) this.deps.registry.indexTool(id, session.sessionId);
       return { session, pump };
     } catch (error) {

--- a/src/core/run-coordinator.ts
+++ b/src/core/run-coordinator.ts
@@ -31,8 +31,8 @@ import { decideOrdinaryTurn } from "./ordinary-turn.js";
 import type { OrdinaryTurnJournal, OrdinaryTurnRecord } from "./ordinary-turn-journal.js";
 import { Session } from "./session.js";
 import { SessionRegistry } from "./session-registry.js";
-import { SdkRunDriver } from "./sdk-run-driver.js";
-import { batchDigest, mapClientTools } from "./tool-bridge.js";
+import { SdkRunDriver, type SdkAgentSource } from "./sdk-run-driver.js";
+import { batchDigest } from "./tool-bridge.js";
 import { buildTranscriptRecovery } from "./transcript-recovery.js";
 import type { LineageRecord, LineageStore } from "./lineage-store.js";
 import type { TurnWriter, TurnWriterFactory, TurnWriterSession } from "./turn-writer.js";
@@ -45,6 +45,13 @@ interface OrdinaryReplayEntry {
   turn: NonNullable<Session["replay"]>["turn"];
   writerSession: TurnWriterSession;
   expiresAt: number;
+}
+
+interface FollowUpOptions {
+  send?: { text: string; images: Array<{ data: string; mimeType: string }> };
+  agent?: SdkAgentSource;
+  afterAgentReady?: () => void;
+  failureReason?: string;
 }
 
 export interface CoordinatorDeps {
@@ -363,7 +370,7 @@ export class RunCoordinator {
           live,
           requestId,
           writerFactory,
-          currentTurnSendPayload(turn),
+          { send: currentTurnSendPayload(turn) },
         );
         return;
       }
@@ -423,39 +430,33 @@ export class RunCoordinator {
       executableToolCatalogFingerprint: executableToolCatalogFingerprint(parsed.tools),
     });
     session.ordinaryReplayOwner = turn;
-    try {
-      const customTools = mapClientTools(parsed.tools, session, this.deps.clock, () => undefined);
-      const agent = await this.deps.sdk.resumeAgent({
-        agentId: parent.agentId,
-        apiKey: auth.cursorApiKey,
-        modelId: parsed.model,
-        modelParams: session.modelParams,
-        workspaceDir: this.deps.workspaceDir,
-        clientToolNames: parsed.tools.map((tool) => tool.name),
-        customTools,
-      });
-      session.agent = agent;
-      session.sdkAgentId = parent.agentId;
-      this.traceOrdinary({
-        action: "resume",
-        reason: "exact_successor_store",
-        model: parsed.model,
-        send_chars: currentTurnSendPayload(turn).text.length,
-      });
-      await this.followUp(
-        req,
-        res,
-        auth,
-        parsed,
-        session,
-        requestId,
-        writerFactory,
-        currentTurnSendPayload(turn),
-      );
-    } catch (error) {
-      if (!res.headersSent) this.deps.registry.forget(session, "ordinary_resume_failed");
-      throw sdkFailure(error);
-    }
+    await this.followUp(
+      req,
+      res,
+      auth,
+      parsed,
+      session,
+      requestId,
+      writerFactory,
+      {
+        send: currentTurnSendPayload(turn),
+        agent: {
+          type: "resume",
+          agentId: parent.agentId,
+          apiKey: auth.cursorApiKey,
+          workspaceDir: this.deps.workspaceDir,
+        },
+        afterAgentReady: () => {
+          this.traceOrdinary({
+            action: "resume",
+            reason: "exact_successor_store",
+            model: parsed.model,
+            send_chars: currentTurnSendPayload(turn).text.length,
+          });
+        },
+        failureReason: "ordinary_resume_failed",
+      },
+    );
   }
 
   private traceOrdinary(event: {
@@ -580,13 +581,16 @@ export class RunCoordinator {
     session: Session,
     requestId: string,
     writerFactory: TurnWriterFactory,
-    sendOverride?: { text: string; images: Array<{ data: string; mimeType: string }> },
+    options: FollowUpOptions = {},
   ): Promise<void> {
     this.assertIdentity(session, auth, parsed);
     if (!session.ordinaryReplayOwner) {
       this.beginOrdinaryReplaySegment(session, auth, parsed);
     }
-    if (!session.agent) {
+    const agentSource = options.agent ?? (session.agent
+      ? { type: "existing" as const, agent: session.agent }
+      : undefined);
+    if (!agentSource) {
       throw sessionLost("Session cannot accept a follow-up send");
     }
     if (session.state !== "completed" && session.state !== "creating") {
@@ -605,17 +609,18 @@ export class RunCoordinator {
     session.lastResultDigest = undefined;
     session.replay = undefined;
     session.appliedBoundaryId = undefined;
-    const prompt = sendOverride ?? renderPrompt(parsed);
+    const prompt = options.send ?? renderPrompt(parsed);
     try {
       const pump = await this.sdkRunDriver.start({
         session,
         tools: parsed.tools,
-        agent: { type: "existing", agent: session.agent },
+        agent: agentSource,
         send: prompt,
+        afterAgentReady: options.afterAgentReady,
       });
       await this.drive(req, res, session, pump, parsed.stream, requestId, writerFactory);
     } catch (error) {
-      if (!res.headersSent) this.deps.registry.forget(session, "follow_up_failed");
+      if (!res.headersSent) this.deps.registry.forget(session, options.failureReason ?? "follow_up_failed");
       throw sdkFailure(error);
     }
   }
@@ -1064,26 +1069,15 @@ export class RunCoordinator {
       clock: this.deps.clock,
     });
     this.deps.registry.adopt(session);
-    try {
-      const customTools = mapClientTools(parsed.tools, session, this.deps.clock, () => undefined);
-      const agent = await this.deps.sdk.resumeAgent({
+    await this.followUp(req, res, auth, parsed, session, requestId, writerFactory, {
+      agent: {
+        type: "resume",
         agentId: record.sdkAgentId,
         apiKey: auth.cursorApiKey,
-        modelId: parsed.model,
-        modelParams: session.modelParams,
         workspaceDir: this.deps.workspaceDir,
-        clientToolNames: parsed.tools.map((tool) => tool.name),
-        customTools,
-      });
-      session.agent = agent;
-      session.sdkAgentId = record.sdkAgentId;
-      await this.followUp(req, res, auth, parsed, session, requestId, writerFactory);
-    } catch (error) {
-      if (!res.headersSent) {
-        this.deps.registry.forget(session, "resume_failed");
-      }
-      throw sdkFailure(error);
-    }
+      },
+      failureReason: "resume_failed",
+    });
   }
 
   private persistLineage(session: Session): void {

--- a/src/core/run-coordinator.ts
+++ b/src/core/run-coordinator.ts
@@ -348,7 +348,7 @@ export class RunCoordinator {
         live.sessionPolicyFingerprint === turn.lineage.sessionPolicyFingerprint &&
         claim.parent.credentialFingerprint === auth.fingerprint
       ) {
-        live.ordinaryTurn = turn;
+        live.ordinaryReplayOwner = turn;
         this.traceOrdinary({
           action: "resume",
           reason: "exact_successor_live",
@@ -422,7 +422,7 @@ export class RunCoordinator {
       sessionPolicyFingerprint: turn.lineage.sessionPolicyFingerprint,
       executableToolCatalogFingerprint: executableToolCatalogFingerprint(parsed.tools),
     });
-    session.ordinaryTurn = turn;
+    session.ordinaryReplayOwner = turn;
     try {
       const customTools = mapClientTools(parsed.tools, session, this.deps.clock, () => undefined);
       const agent = await this.deps.sdk.resumeAgent({
@@ -493,7 +493,7 @@ export class RunCoordinator {
   }
 
   private rememberOrdinaryCompletion(session: Session): void {
-    const turn = session.ordinaryTurn;
+    const turn = session.ordinaryReplayOwner;
     const journal = this.deps.ordinaryJournal;
     if (!turn || !journal || !session.replay) return;
     if (session.state !== "completed" && session.state !== "awaiting_tool_results") return;
@@ -529,6 +529,7 @@ export class RunCoordinator {
       },
       expiresAt: completed.expiresAt,
     });
+    session.ordinaryReplayOwner = undefined;
     if (session.state === "completed") {
       session.retainOrdinaryAgent = true;
       session.retainUntil = completed.expiresAt;
@@ -552,7 +553,7 @@ export class RunCoordinator {
       sessionPolicyFingerprint: sessionPolicyFingerprintFromParsed(parsed),
       executableToolCatalogFingerprint: executableToolCatalogFingerprint(parsed.tools),
     });
-    if (ordinaryTurn) session.ordinaryTurn = ordinaryTurn;
+    if (ordinaryTurn) session.ordinaryReplayOwner = ordinaryTurn;
     try {
       const prompt = sendOverride ?? renderPrompt(parsed);
       const pump = await this.sdkRunDriver.start({
@@ -582,6 +583,9 @@ export class RunCoordinator {
     sendOverride?: { text: string; images: Array<{ data: string; mimeType: string }> },
   ): Promise<void> {
     this.assertIdentity(session, auth, parsed);
+    if (!session.ordinaryReplayOwner) {
+      this.beginOrdinaryReplaySegment(session, auth, parsed);
+    }
     if (!session.agent) {
       throw sessionLost("Session cannot accept a follow-up send");
     }
@@ -734,6 +738,7 @@ export class RunCoordinator {
     if (unknown.length > 0) throw invalidRequest(`unknown tool_use_id: ${unknown.join(",")}`);
     if (missing.length > 0) throw invalidRequest(`missing tool_result for: ${missing.join(",")}`);
 
+    this.beginOrdinaryReplaySegment(session, auth, parsed);
     session.pump.beginNextSegment();
     session.lastResultDigest = digest;
     session.state = "resuming";
@@ -813,6 +818,7 @@ export class RunCoordinator {
       sessionPolicyFingerprint: sessionPolicyFingerprintFromParsed(parsed),
       executableToolCatalogFingerprint: executableToolCatalogFingerprint(parsed.tools),
     });
+    this.beginOrdinaryReplaySegment(session, auth, parsed);
     session.lastResultDigest = batchDigest(results);
     try {
       const pump = await this.sdkRunDriver.start({
@@ -904,6 +910,7 @@ export class RunCoordinator {
       clock: this.deps.clock,
     });
     session.state = "resuming";
+    this.beginOrdinaryReplaySegment(session, auth, parsed);
     session.lastResultDigest = digest;
     this.deps.registry.adopt(session);
 
@@ -1139,6 +1146,20 @@ export class RunCoordinator {
       messageId: turn.messageId,
     });
     writer.finish(turn, { replayed: true });
+  }
+
+  private beginOrdinaryReplaySegment(
+    session: Session,
+    auth: AuthContext,
+    parsed: ParsedMessages,
+  ): void {
+    if (!this.deps.config.ordinaryTurnCoordinator || !this.deps.ordinaryJournal) return;
+    if (session.ordinaryReplayOwner) {
+      throw sessionConflict("session already has an active ordinary replay segment owner");
+    }
+    session.ordinaryReplayOwner = cursorAgentTurnFromParsed(parsed, {
+      tenantScope: auth.fingerprint,
+    });
   }
 
   private assertIdentity(

--- a/src/core/run-coordinator.ts
+++ b/src/core/run-coordinator.ts
@@ -584,9 +584,6 @@ export class RunCoordinator {
     options: FollowUpOptions = {},
   ): Promise<void> {
     this.assertIdentity(session, auth, parsed);
-    if (!session.ordinaryReplayOwner) {
-      this.beginOrdinaryReplaySegment(session, auth, parsed);
-    }
     const agentSource = options.agent ?? (session.agent
       ? { type: "existing" as const, agent: session.agent }
       : undefined);

--- a/src/core/run-coordinator.ts
+++ b/src/core/run-coordinator.ts
@@ -36,6 +36,10 @@ import { batchDigest, mapClientTools } from "./tool-bridge.js";
 import { buildTranscriptRecovery } from "./transcript-recovery.js";
 import type { LineageRecord, LineageStore } from "./lineage-store.js";
 import type { TurnWriter, TurnWriterFactory, TurnWriterSession } from "./turn-writer.js";
+import {
+  executableToolCatalogFingerprint,
+  sessionPolicyFingerprintFromParsed,
+} from "./session-policy.js";
 
 interface OrdinaryReplayEntry {
   turn: NonNullable<Session["replay"]>["turn"];
@@ -69,7 +73,14 @@ function sameModelParams(
   right: Array<{ id: string; value: string }>,
 ): boolean {
   if (left.length !== right.length) return false;
-  return left.every((item, index) => item.id === right[index]?.id && item.value === right[index]?.value);
+  const normalized = (items: Array<{ id: string; value: string }>) =>
+    [...items].sort((a, b) => a.id.localeCompare(b.id) || a.value.localeCompare(b.value));
+  const normalizedLeft = normalized(left);
+  const normalizedRight = normalized(right);
+  return normalizedLeft.every(
+    (item, index) =>
+      item.id === normalizedRight[index]?.id && item.value === normalizedRight[index]?.value,
+  );
 }
 
 export class RunCoordinator {
@@ -284,6 +295,7 @@ export class RunCoordinator {
       parentAssistantAnchor: turn.lineage.parentAssistantAnchor,
       turnIndex: turn.lineage.turnIndex,
       toolCatalogDigest: turn.lineage.toolCatalogDigest,
+      sessionPolicyFingerprint: turn.lineage.sessionPolicyFingerprint,
       assistantAnchor: "",
       agentId: claim.mode === "resume" ? claim.parent.agentId : "",
       credentialFingerprint: auth.fingerprint,
@@ -333,6 +345,7 @@ export class RunCoordinator {
         live.state === "completed" &&
         live.credentialFingerprint === auth.fingerprint &&
         live.modelId === parsed.model &&
+        live.sessionPolicyFingerprint === turn.lineage.sessionPolicyFingerprint &&
         claim.parent.credentialFingerprint === auth.fingerprint
       ) {
         live.ordinaryTurn = turn;
@@ -396,6 +409,9 @@ export class RunCoordinator {
     requestId: string,
     writerFactory: TurnWriterFactory,
   ): Promise<void> {
+    if (parent.sessionPolicyFingerprint !== turn.lineage.sessionPolicyFingerprint) {
+      throw sessionConflict("session policy does not match the ordinary-turn owner");
+    }
     this.deps.registry.assertCanActivateRun({
       credentialFingerprint: auth.fingerprint,
     });
@@ -403,6 +419,8 @@ export class RunCoordinator {
       credentialFingerprint: auth.fingerprint,
       modelId: parsed.model,
       modelParams: parsed.modelParams,
+      sessionPolicyFingerprint: turn.lineage.sessionPolicyFingerprint,
+      executableToolCatalogFingerprint: executableToolCatalogFingerprint(parsed.tools),
     });
     session.ordinaryTurn = turn;
     try {
@@ -492,6 +510,7 @@ export class RunCoordinator {
       parentAssistantAnchor: turn.lineage.parentAssistantAnchor,
       turnIndex: turn.lineage.turnIndex,
       toolCatalogDigest: turn.lineage.toolCatalogDigest,
+      sessionPolicyFingerprint: session.sessionPolicyFingerprint,
       assistantAnchor,
       agentId: session.sdkAgentId ?? session.agent?.agentId ?? "",
       credentialFingerprint: session.credentialFingerprint,
@@ -530,6 +549,8 @@ export class RunCoordinator {
       credentialFingerprint: auth.fingerprint,
       modelId: parsed.model,
       modelParams: parsed.modelParams,
+      sessionPolicyFingerprint: sessionPolicyFingerprintFromParsed(parsed),
+      executableToolCatalogFingerprint: executableToolCatalogFingerprint(parsed.tools),
     });
     if (ordinaryTurn) session.ordinaryTurn = ordinaryTurn;
     try {
@@ -560,7 +581,7 @@ export class RunCoordinator {
     writerFactory: TurnWriterFactory,
     sendOverride?: { text: string; images: Array<{ data: string; mimeType: string }> },
   ): Promise<void> {
-    this.assertIdentity(session, auth, parsed.model, parsed.modelParams);
+    this.assertIdentity(session, auth, parsed);
     if (!session.agent) {
       throw sessionLost("Session cannot accept a follow-up send");
     }
@@ -619,6 +640,18 @@ export class RunCoordinator {
       routingError = invalidRequest(`unknown tool_use_id: ${lookup.missing.join(",")}`);
     }
     if (!lookup.mixed && lookup.session && lookup.missing.length === 0) {
+      const effectiveParams =
+        parsed.modelParams.length > 0 ? parsed.modelParams : lookup.session.modelParams;
+      if (parsed.modelParams.length > 0 && !sameModelParams(lookup.session.modelParams, effectiveParams)) {
+        throw sessionConflict("model parameters do not match the live pending session");
+      }
+      if (
+        parsed.tools.length > 0 &&
+        lookup.session.executableToolCatalogFingerprint !==
+          executableToolCatalogFingerprint(parsed.tools)
+      ) {
+        throw sessionConflict("session policy does not match the live pending session");
+      }
       try {
         await this.continueLiveSession(req, res, auth, parsed, results, lookup.session, requestId, writerFactory);
         return;
@@ -630,6 +663,18 @@ export class RunCoordinator {
     if (!lookup.mixed && !lookup.session) {
       const recorded = this.deps.lineage?.findByToolIds(ids);
       if (recorded) {
+        const effectiveParams =
+          parsed.modelParams.length > 0 ? parsed.modelParams : recorded.modelParams ?? [];
+        if (parsed.modelParams.length > 0 && !sameModelParams(recorded.modelParams ?? [], effectiveParams)) {
+          throw sessionConflict("model parameters do not match the stored pending session");
+        }
+        if (
+          parsed.tools.length > 0 &&
+          recorded.executableToolCatalogFingerprint !==
+            executableToolCatalogFingerprint(parsed.tools)
+        ) {
+          throw sessionConflict("session policy does not match the stored pending session");
+        }
         try {
           await this.resumePendingLineage(
             req,
@@ -663,7 +708,7 @@ export class RunCoordinator {
   ): Promise<void> {
     const ids = results.map((result) => result.toolUseId);
     this.deps.registry.requireLive(session, ids);
-    this.assertIdentity(session, auth, parsed.model, parsed.modelParams);
+    this.assertPendingIdentity(session, auth, parsed);
 
     const digest = batchDigest(results);
     if (session.lastResultDigest && session.lastResultDigest !== digest) {
@@ -765,6 +810,8 @@ export class RunCoordinator {
       credentialFingerprint: auth.fingerprint,
       modelId: parsed.model,
       modelParams: parsed.modelParams,
+      sessionPolicyFingerprint: sessionPolicyFingerprintFromParsed(parsed),
+      executableToolCatalogFingerprint: executableToolCatalogFingerprint(parsed.tools),
     });
     session.lastResultDigest = batchDigest(results);
     try {
@@ -851,6 +898,8 @@ export class RunCoordinator {
       credentialFingerprint: record.credentialFingerprint,
       modelId: record.modelId,
       modelParams: record.modelParams,
+      sessionPolicyFingerprint: record.sessionPolicyFingerprint,
+      executableToolCatalogFingerprint: record.executableToolCatalogFingerprint,
       instanceId: this.deps.registry.instanceId,
       clock: this.deps.clock,
     });
@@ -984,6 +1033,10 @@ export class RunCoordinator {
     if (record.credentialFingerprint !== auth.fingerprint || record.modelId !== parsed.model) {
       throw sessionConflict("credential or model does not match the stored session");
     }
+    const effectiveParams = parsed.modelParams.length > 0 ? parsed.modelParams : record.modelParams ?? [];
+    if (record.sessionPolicyFingerprint !== sessionPolicyFingerprintFromParsed(parsed, effectiveParams)) {
+      throw sessionConflict("session policy does not match the stored session");
+    }
     if (parsed.modelParams.length > 0 && !sameModelParams(record.modelParams ?? [], parsed.modelParams)) {
       throw sessionConflict("model parameters do not match the stored session");
     }
@@ -998,6 +1051,8 @@ export class RunCoordinator {
       credentialFingerprint: record.credentialFingerprint,
       modelId: record.modelId,
       modelParams: record.modelParams,
+      sessionPolicyFingerprint: record.sessionPolicyFingerprint,
+      executableToolCatalogFingerprint: record.executableToolCatalogFingerprint,
       instanceId: this.deps.registry.instanceId,
       clock: this.deps.clock,
     });
@@ -1034,12 +1089,14 @@ export class RunCoordinator {
     const ttl =
       session.state === "failed" ? this.deps.config.replayTtlMs : this.deps.config.sessionTtlMs;
     const record: LineageRecord = {
-      version: 1,
+      version: 2,
       sessionId: session.sessionId,
       sdkAgentId,
       credentialFingerprint: session.credentialFingerprint,
       modelId: session.modelId,
       ...(session.modelParams.length > 0 ? { modelParams: session.modelParams } : {}),
+      sessionPolicyFingerprint: session.sessionPolicyFingerprint,
+      executableToolCatalogFingerprint: session.executableToolCatalogFingerprint,
       state: session.state as LineageRecord["state"],
       pendingToolIds:
         session.state === "awaiting_tool_results" ? [...session.pending.keys()] : [],
@@ -1087,16 +1144,41 @@ export class RunCoordinator {
   private assertIdentity(
     session: Session,
     auth: AuthContext,
-    model: string,
-    requestedParams: Array<{ id: string; value: string }>,
+    parsed: ParsedMessages,
+  ): void {
+    this.assertModelIdentity(session, auth, parsed);
+    const effectiveParams = parsed.modelParams.length > 0 ? parsed.modelParams : session.modelParams;
+    if (session.sessionPolicyFingerprint !== sessionPolicyFingerprintFromParsed(parsed, effectiveParams)) {
+      throw sessionConflict("session policy does not match the session owner");
+    }
+  }
+
+  private assertPendingIdentity(
+    session: Session,
+    auth: AuthContext,
+    parsed: ParsedMessages,
+  ): void {
+    this.assertModelIdentity(session, auth, parsed);
+    if (
+      parsed.tools.length > 0 &&
+      session.executableToolCatalogFingerprint !== executableToolCatalogFingerprint(parsed.tools)
+    ) {
+      throw sessionConflict("tool catalog does not match the pending session owner");
+    }
+  }
+
+  private assertModelIdentity(
+    session: Session,
+    auth: AuthContext,
+    parsed: ParsedMessages,
   ): void {
     if (session.credentialFingerprint !== auth.fingerprint) {
       throw sessionConflict("credential identity does not match the session owner");
     }
-    if (session.modelId !== model) {
+    if (session.modelId !== parsed.model) {
       throw sessionConflict("model does not match the session owner");
     }
-    if (requestedParams.length > 0 && !sameModelParams(session.modelParams, requestedParams)) {
+    if (parsed.modelParams.length > 0 && !sameModelParams(session.modelParams, parsed.modelParams)) {
       throw sessionConflict("model parameters do not match the session owner");
     }
     if (session.instanceId !== this.deps.registry.instanceId) {

--- a/src/core/run-coordinator.ts
+++ b/src/core/run-coordinator.ts
@@ -34,7 +34,13 @@ import { SessionRegistry } from "./session-registry.js";
 import { batchDigest, mapClientTools } from "./tool-bridge.js";
 import { buildTranscriptRecovery } from "./transcript-recovery.js";
 import type { LineageRecord, LineageStore } from "./lineage-store.js";
-import type { TurnWriter, TurnWriterFactory } from "./turn-writer.js";
+import type { TurnWriter, TurnWriterFactory, TurnWriterSession } from "./turn-writer.js";
+
+interface OrdinaryReplayEntry {
+  turn: NonNullable<Session["replay"]>["turn"];
+  writerSession: TurnWriterSession;
+  expiresAt: number;
+}
 
 export interface CoordinatorDeps {
   config: GatewayConfig;
@@ -98,13 +104,25 @@ export class RunCoordinator {
     { expiresAt: number; promise: Promise<{ session: Session; pump: EventPump }> }
   >();
   private readonly ordinaryInflight = new Map<string, Promise<void>>();
-  private readonly ordinaryReplay = new Map<string, { session: Session; expiresAt: number }>();
+  private readonly ordinaryReplay = new Map<string, OrdinaryReplayEntry>();
 
   constructor(private readonly deps: CoordinatorDeps) {
     this.deps.ordinaryJournal?.setOnExpire((record) => {
       const session = this.findSessionByAgentId(record.agentId);
       if (session) this.deps.registry.forget(session, "ordinary_turn_expired");
     });
+  }
+
+  ordinaryReplayCount(): number {
+    return this.ordinaryReplay.size;
+  }
+
+  sweepOrdinaryState(): void {
+    this.deps.ordinaryJournal?.sweepExpired();
+    const now = this.deps.clock.now();
+    for (const [key, replay] of this.ordinaryReplay) {
+      if (now >= replay.expiresAt) this.ordinaryReplay.delete(key);
+    }
   }
 
   async handleMessages(
@@ -117,7 +135,7 @@ export class RunCoordinator {
     writerFactory: TurnWriterFactory = createAnthropicWriter,
   ): Promise<void> {
     this.deps.registry.sweep();
-    this.deps.ordinaryJournal?.sweepExpired();
+    this.sweepOrdinaryState();
     if (parsed.continuation) {
       await this.continueTurn(req, res, auth, parsed, parsed.continuation, requestId, writerFactory);
       return;
@@ -173,10 +191,10 @@ export class RunCoordinator {
     if (inflight) {
       await inflight;
       const cached = this.ordinaryReplay.get(key);
-      if (!cached?.session.replay) {
+      if (!cached) {
         throw sessionLost("completed Cursor ordinary turn cannot be replayed without its in-memory response");
       }
-      this.writeReplay(res, cached.session, parsed.stream, requestId, writerFactory);
+      this.writeReplay(res, cached, parsed.stream, requestId, writerFactory);
       return true;
     }
 
@@ -192,10 +210,10 @@ export class RunCoordinator {
     if (decision.action === "tool_continuation") return false;
     if (decision.action === "replay") {
       const cached = this.ordinaryReplay.get(key);
-      if (!cached?.session.replay) {
+      if (!cached) {
         throw sessionLost("completed Cursor ordinary turn cannot be replayed without its in-memory response");
       }
-      this.writeReplay(res, cached.session, parsed.stream, requestId, writerFactory);
+      this.writeReplay(res, cached, parsed.stream, requestId, writerFactory);
       return true;
     }
     if (decision.action === "fail_closed") {
@@ -206,10 +224,10 @@ export class RunCoordinator {
       if (pending) {
         await pending;
         const cached = this.ordinaryReplay.get(key);
-        if (!cached?.session.replay) {
+        if (!cached) {
           throw sessionLost("completed Cursor ordinary turn cannot be replayed without its in-memory response");
         }
-        this.writeReplay(res, cached.session, parsed.stream, requestId, writerFactory);
+        this.writeReplay(res, cached, parsed.stream, requestId, writerFactory);
         return true;
       }
     }
@@ -253,10 +271,10 @@ export class RunCoordinator {
     if (existing) {
       await existing;
       const cached = this.ordinaryReplay.get(key);
-      if (!cached?.session.replay) {
+      if (!cached) {
         throw sessionLost("completed Cursor ordinary turn cannot be replayed without its in-memory response");
       }
-      this.writeReplay(res, cached.session, parsed.stream, requestId, writerFactory);
+      this.writeReplay(res, cached, parsed.stream, requestId, writerFactory);
       return;
     }
 
@@ -499,7 +517,12 @@ export class RunCoordinator {
     };
     journal.upsert(completed);
     this.ordinaryReplay.set(ordinaryReplayKey(turn), {
-      session,
+      turn: structuredClone(session.replay.turn),
+      writerSession: {
+        sessionId: session.sessionId,
+        modelId: session.modelId,
+        createdAt: session.createdAt,
+      },
       expiresAt: completed.expiresAt,
     });
     if (session.state === "completed") {
@@ -697,7 +720,7 @@ export class RunCoordinator {
       throw sessionConflict("duplicate tool_use_id with a different result digest");
     }
     if (session.lastResultDigest === digest && session.state === "completed" && session.replay) {
-      this.writeReplay(res, session, parsed.stream, requestId, writerFactory);
+      this.writeReplay(res, { turn: session.replay.turn, writerSession: session }, parsed.stream, requestId, writerFactory);
       return;
     }
     if (session.state === "resuming" && session.lastResultDigest === digest && session.pump) {
@@ -1142,18 +1165,17 @@ export class RunCoordinator {
 
   private writeReplay(
     res: ServerResponse,
-    session: Session,
+    replay: { turn: NonNullable<Session["replay"]>["turn"]; writerSession: TurnWriterSession },
     stream: boolean,
     requestId: string,
     writerFactory: TurnWriterFactory,
   ): void {
-    const turn = session.replay?.turn;
-    if (!turn) throw sessionLost("Replay record is missing");
+    const turn = replay.turn;
     const writer = writerFactory({
       res,
       stream,
       requestId,
-      session,
+      session: replay.writerSession,
       messageId: turn.messageId,
     });
     writer.finish(turn, { replayed: true });

--- a/src/core/sdk-run-driver.ts
+++ b/src/core/sdk-run-driver.ts
@@ -10,7 +10,7 @@ import { EventPump } from "./event-pump.js";
 import type { Session } from "./session.js";
 import { mapClientTools } from "./tool-bridge.js";
 
-type AgentSource =
+export type SdkAgentSource =
   | { type: "create"; apiKey: string; workspaceDir: string }
   | { type: "resume"; agentId: string; apiKey: string; workspaceDir: string }
   | { type: "existing"; agent: SdkAgent };
@@ -18,13 +18,14 @@ type AgentSource =
 export interface DriveSdkRunInput {
   session: Session;
   tools: AnthropicTool[];
-  agent: AgentSource;
+  agent: SdkAgentSource;
   send: {
     text: string;
     images?: Array<{ data: string; mimeType: string }>;
     force?: boolean;
   };
   completedResults?: Map<string, SdkCustomToolResult[]>;
+  afterAgentReady?: (agent: SdkAgent) => void;
 }
 
 export interface SdkRunDriverDeps {
@@ -74,6 +75,7 @@ export class SdkRunDriver {
     const agent = await this.resolveAgent(input, customTools);
     session.agent = agent;
     session.sdkAgentId = agent.agentId;
+    input.afterAgentReady?.(agent);
 
     const deltas = createDeltaBridge();
     const run = await agent.send({

--- a/src/core/sdk-run-driver.ts
+++ b/src/core/sdk-run-driver.ts
@@ -1,0 +1,125 @@
+import type { Clock } from "../clock.js";
+import type { AnthropicTool } from "../protocols/anthropic/types.js";
+import type {
+  SdkAgent,
+  SdkCustomToolResult,
+  SdkDeltaUpdate,
+  SdkRuntime,
+} from "../sdk/port.js";
+import { EventPump } from "./event-pump.js";
+import type { Session } from "./session.js";
+import { mapClientTools } from "./tool-bridge.js";
+
+type AgentSource =
+  | { type: "create"; apiKey: string; workspaceDir: string }
+  | { type: "resume"; agentId: string; apiKey: string; workspaceDir: string }
+  | { type: "existing"; agent: SdkAgent };
+
+export interface DriveSdkRunInput {
+  session: Session;
+  tools: AnthropicTool[];
+  agent: AgentSource;
+  send: {
+    text: string;
+    images?: Array<{ data: string; mimeType: string }>;
+    force?: boolean;
+  };
+  completedResults?: Map<string, SdkCustomToolResult[]>;
+}
+
+export interface SdkRunDriverDeps {
+  sdk: SdkRuntime;
+  clock: Clock;
+  toolBatchSettleMs: number;
+  firstEventTimeoutMs: number;
+}
+
+function createDeltaBridge() {
+  const early: SdkDeltaUpdate[] = [];
+  let pump: EventPump | undefined;
+  const ingest = (update: SdkDeltaUpdate) => {
+    early.push(update);
+    flush();
+  };
+  const flush = () => {
+    if (!pump) return;
+    while (early.length > 0) {
+      const next = early.shift();
+      if (next) pump.ingestDelta(next);
+    }
+  };
+  return {
+    ingest,
+    attach(next: EventPump) {
+      pump = next;
+      flush();
+    },
+  };
+}
+
+export class SdkRunDriver {
+  constructor(private readonly deps: SdkRunDriverDeps) {}
+
+  async start(input: DriveSdkRunInput): Promise<EventPump> {
+    const { session } = input;
+    session.run = undefined;
+    session.pump = undefined;
+    const customTools = mapClientTools(
+      input.tools,
+      session,
+      this.deps.clock,
+      () => undefined,
+      input.completedResults,
+    );
+    const agent = await this.resolveAgent(input, customTools);
+    session.agent = agent;
+    session.sdkAgentId = agent.agentId;
+
+    const deltas = createDeltaBridge();
+    const run = await agent.send({
+      text: input.send.text,
+      images: input.send.images,
+      customTools,
+      force: input.send.force,
+      onDelta: deltas.ingest,
+    });
+    session.run = run;
+    const pump = new EventPump(
+      session,
+      run,
+      this.deps.clock,
+      this.deps.toolBatchSettleMs,
+      this.deps.firstEventTimeoutMs,
+    );
+    session.pump = pump;
+    deltas.attach(pump);
+    pump.ingestEarly(session.earlyCalls.splice(0));
+    return pump;
+  }
+
+  private resolveAgent(
+    input: DriveSdkRunInput,
+    customTools: ReturnType<typeof mapClientTools>,
+  ): Promise<SdkAgent> {
+    const common = {
+      modelId: input.session.modelId,
+      modelParams: input.session.modelParams,
+      clientToolNames: input.tools.map((tool) => tool.name),
+      customTools,
+    };
+    if (input.agent.type === "existing") return Promise.resolve(input.agent.agent);
+    if (input.agent.type === "resume") {
+      return this.deps.sdk.resumeAgent({
+        ...common,
+        agentId: input.agent.agentId,
+        apiKey: input.agent.apiKey,
+        workspaceDir: input.agent.workspaceDir,
+      });
+    }
+    return this.deps.sdk.createAgent({
+      ...common,
+      apiKey: input.agent.apiKey,
+      workspaceDir: input.agent.workspaceDir,
+    });
+  }
+}

--- a/src/core/session-policy.ts
+++ b/src/core/session-policy.ts
@@ -1,0 +1,60 @@
+import { digestJson, stableStringify } from "../digest.js";
+import type { AnthropicTool, ParsedMessages } from "../protocols/anthropic/types.js";
+import type { ToolChoicePolicy } from "../protocols/tool-choice.js";
+
+export interface SessionPolicyInput {
+  modelId: string;
+  modelParams: Array<{ id: string; value: string }>;
+  tools: AnthropicTool[];
+  toolChoice: ToolChoicePolicy | null;
+}
+
+export function sessionPolicyFingerprint(input: SessionPolicyInput): string {
+  return digestJson({
+    model: {
+      id: input.modelId,
+      params: normalizeModelParams(input.modelParams),
+    },
+    tools: normalizeExecutableTools(input.tools),
+    toolChoice: input.toolChoice,
+  });
+}
+
+export function executableToolCatalogFingerprint(tools: AnthropicTool[]): string {
+  return digestJson(normalizeExecutableTools(tools));
+}
+
+export function sessionPolicyFingerprintFromParsed(
+  parsed: ParsedMessages,
+  effectiveModelParams: Array<{ id: string; value: string }> = parsed.modelParams,
+): string {
+  return sessionPolicyFingerprint({
+    modelId: parsed.model,
+    modelParams: effectiveModelParams,
+    tools: parsed.tools,
+    toolChoice: parsed.toolChoice ?? null,
+  });
+}
+
+export function normalizeModelParams(
+  params: Array<{ id: string; value: string }>,
+): Array<{ id: string; value: string }> {
+  return params
+    .map((param) => ({ id: param.id, value: param.value }))
+    .sort((left, right) =>
+      left.id.localeCompare(right.id) || left.value.localeCompare(right.value),
+    );
+}
+
+function normalizeExecutableTools(tools: AnthropicTool[]): Array<Record<string, unknown>> {
+  return tools
+    .map((tool) => ({
+      publicName: tool.name,
+      sdkName: tool.sdk_name ?? tool.name,
+      kind: tool.tool_kind ?? "function",
+      namespace: tool.namespace ?? "",
+      description: tool.description ?? "",
+      inputSchema: tool.input_schema ?? null,
+    }))
+    .sort((left, right) => stableStringify(left).localeCompare(stableStringify(right)));
+}

--- a/src/core/session-registry.ts
+++ b/src/core/session-registry.ts
@@ -29,6 +29,8 @@ export class SessionRegistry {
     credentialFingerprint: string;
     modelId: string;
     modelParams?: Array<{ id: string; value: string }>;
+    sessionPolicyFingerprint: string;
+    executableToolCatalogFingerprint: string;
   }): Session {
     this.assertCanActivateRun({ credentialFingerprint: input.credentialFingerprint });
     const awaiting = [...this.sessions.values()].filter((session) => session.state === "awaiting_tool_results");

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -59,7 +59,7 @@ export class Session {
   lastResultDigest?: string;
   appliedBoundaryId?: string;
   closeReason?: string;
-  ordinaryTurn?: CursorAgentTurn;
+  ordinaryReplayOwner?: CursorAgentTurn;
   retainOrdinaryAgent = false;
   retainUntil = 0;
 

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -40,6 +40,8 @@ export class Session {
   readonly credentialFingerprint: string;
   readonly modelId: string;
   readonly modelParams: Array<{ id: string; value: string }>;
+  readonly sessionPolicyFingerprint: string;
+  readonly executableToolCatalogFingerprint: string;
   readonly instanceId: string;
   readonly createdAt: number;
   lastActivityAt: number;
@@ -65,6 +67,8 @@ export class Session {
     credentialFingerprint: string;
     modelId: string;
     modelParams?: Array<{ id: string; value: string }>;
+    sessionPolicyFingerprint: string;
+    executableToolCatalogFingerprint: string;
     instanceId: string;
     clock: Clock;
     sessionId?: string;
@@ -73,6 +77,8 @@ export class Session {
     this.credentialFingerprint = input.credentialFingerprint;
     this.modelId = input.modelId;
     this.modelParams = [...(input.modelParams ?? [])];
+    this.sessionPolicyFingerprint = input.sessionPolicyFingerprint;
+    this.executableToolCatalogFingerprint = input.executableToolCatalogFingerprint;
     this.instanceId = input.instanceId;
     this.createdAt = input.clock.now();
     this.lastActivityAt = this.createdAt;

--- a/src/core/turn-writer.ts
+++ b/src/core/turn-writer.ts
@@ -8,10 +8,12 @@ export interface TurnWriter extends ResponseSink {
   fail(error: unknown): void;
 }
 
+export type TurnWriterSession = Pick<Session, "sessionId" | "modelId" | "createdAt">;
+
 export interface TurnWriterContext {
   res: ServerResponse;
   requestId: string;
-  session: Session;
+  session: TurnWriterSession;
   stream: boolean;
   messageId: string;
 }

--- a/src/sdk/cursor-runtime.ts
+++ b/src/sdk/cursor-runtime.ts
@@ -38,7 +38,7 @@ function readSdkVersion(): string {
   } catch {
     // fall through
   }
-  return "1.0.28";
+  return "1.0.30";
 }
 
 function mapUsage(raw: unknown): SdkUsage | undefined {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -299,7 +299,7 @@ export function createApp(input: {
     try {
       registry.sweep();
       lineage.sweep();
-      ordinaryJournal.sweepExpired();
+      coordinator.sweepOrdinaryState();
     } catch {
       // sweep must not crash the process
     }

--- a/tests/contract/cursor-agent-turn.test.ts
+++ b/tests/contract/cursor-agent-turn.test.ts
@@ -5,8 +5,11 @@ import {
   currentTurnSendPayload,
   digestAssistantAnchor,
   nextCursorAgentTurnLineageKey,
+  ordinaryReplayKey,
 } from "../../src/core/cursor-agent-turn.js";
 import { parseMessagesRequest } from "../../src/protocols/anthropic/parse.js";
+import { parseResponsesRequest } from "../../src/protocols/openai-responses/parse.js";
+import { sessionPolicyFingerprint } from "../../src/core/session-policy.js";
 
 test("string and block assistant content share an anchor", () => {
   expect(digestAssistantAnchor("hello world")).toBe(
@@ -57,4 +60,108 @@ test("next lineage key is the successor parent/turn index", () => {
     { tenantScope: tenant },
   );
   expect(cursorAgentTurnLineageKey(follow)).toBe(nextCursorAgentTurnLineageKey(first, anchor));
+});
+
+test("ordinary replay identity includes system and full conversation history", () => {
+  const tenantScope = "d".repeat(64);
+  const makeTurn = (system: string, firstUser: string) => cursorAgentTurnFromParsed(
+    parseMessagesRequest({
+      model: "composer-2.5",
+      max_tokens: 16,
+      system,
+      messages: [
+        { role: "user", content: firstUser },
+        { role: "assistant", content: "same assistant anchor" },
+        { role: "user", content: "same current text" },
+      ],
+    }),
+    { tenantScope },
+  );
+
+  const systemA = makeTurn("system A", "same earlier user");
+  const systemB = makeTurn("system B", "same earlier user");
+  const historyB = makeTurn("system A", "different earlier user");
+
+  expect(ordinaryReplayKey(systemB)).not.toBe(ordinaryReplayKey(systemA));
+  expect(ordinaryReplayKey(historyB)).not.toBe(ordinaryReplayKey(systemA));
+});
+
+test("Responses executable tool identity changes cannot hit an old ordinary replay", () => {
+  const tenantScope = "e".repeat(64);
+  const namespaceTool = (namespace: string, parameters: Record<string, unknown>) => ({
+    type: "namespace",
+    name: namespace,
+    tools: [{
+      type: "function",
+      name: "lookup",
+      description: "Lookup",
+      parameters,
+    }],
+  });
+  const makeTurn = (additionalTool: Record<string, unknown>) => cursorAgentTurnFromParsed(
+    parseResponsesRequest({
+      model: "composer-2.5",
+      input: [
+        { type: "additional_tools", tools: [additionalTool] },
+        { type: "message", role: "user", content: "same input" },
+      ],
+    }).parsed,
+    { tenantScope, sourceProtocol: "responses" },
+  );
+  const schema = {
+    type: "object",
+    properties: { q: { type: "string", description: "query" } },
+    required: ["q"],
+  };
+  const base = makeTurn(namespaceTool("mcp__exa", schema));
+  const changedNamespace = makeTurn(namespaceTool("mcp__other", schema));
+  const changedSdkName = structuredClone(base);
+  changedSdkName.tools[0]!.sdk_name = "mcp__exa__search";
+  changedSdkName.lineage.sessionPolicyFingerprint = sessionPolicyFingerprint({
+    modelId: changedSdkName.originalModel,
+    modelParams: [],
+    tools: changedSdkName.tools,
+    toolChoice: changedSdkName.toolChoice,
+  });
+  const changedKind = structuredClone(base);
+  changedKind.tools[0]!.tool_kind = "custom";
+  changedKind.lineage.sessionPolicyFingerprint = sessionPolicyFingerprint({
+    modelId: changedKind.originalModel,
+    modelParams: [],
+    tools: changedKind.tools,
+    toolChoice: changedKind.toolChoice,
+  });
+  const changedSchema = makeTurn(namespaceTool("mcp__exa", {
+    type: "object",
+    properties: { q: { type: "number", description: "query" } },
+    required: ["q"],
+  }));
+
+  for (const changed of [changedNamespace, changedSdkName, changedKind, changedSchema]) {
+    expect(ordinaryReplayKey(changed)).not.toBe(ordinaryReplayKey(base));
+  }
+});
+
+test("ordinary replay identity is stable across equivalent object key order", () => {
+  const tenantScope = "f".repeat(64);
+  const makeTurn = (parameters: Record<string, unknown>) => cursorAgentTurnFromParsed(
+    parseResponsesRequest({
+      model: "composer-2.5",
+      input: "same input",
+      tools: [{ type: "function", name: "lookup", parameters }],
+    }).parsed,
+    { tenantScope, sourceProtocol: "responses" },
+  );
+  const original = makeTurn({
+    type: "object",
+    properties: { q: { type: "string", description: "query" } },
+    required: ["q"],
+  });
+  const reordered = makeTurn({
+    required: ["q"],
+    properties: { q: { description: "query", type: "string" } },
+    type: "object",
+  });
+
+  expect(ordinaryReplayKey(reordered)).toBe(ordinaryReplayKey(original));
 });

--- a/tests/contract/health.test.ts
+++ b/tests/contract/health.test.ts
@@ -41,7 +41,7 @@ test("health reports runtime capability truth without account data", async () =>
   };
   expect(body.status).toBe("ok");
   expect(body.service).toBe("cursor-sdk2api");
-  expect(body.sdk_version).toBe("1.0.28");
+  expect(body.sdk_version).toBe("1.0.30");
   expect(body.runtime).toBe("local");
   expect(body.network).toEqual({
     proxy_configured: ctx.app.config.proxyConfigured,

--- a/tests/contract/ordinary-turn-decide.test.ts
+++ b/tests/contract/ordinary-turn-decide.test.ts
@@ -131,6 +131,21 @@ test("identical digest without in-memory replay fails closed", () => {
   expect(decision.action).toBe("fail_closed");
 });
 
+test("exact replay validates the stored session policy before replaying", () => {
+  const store = makeJournal();
+  const first = turn([{ role: "user", content: "hello" }]);
+  store.upsert({ ...completedRecord(first), sessionPolicyFingerprint: "a".repeat(64) });
+
+  expect(decideOrdinaryTurn({
+    turn: first,
+    journal: store,
+    inflight: new Set(),
+    now: 10,
+    enabled: true,
+    hasReplay: true,
+  })).toMatchObject({ action: "rebuild", reason: "lineage_mismatch" });
+});
+
 test("disabled coordinator always rebuilds", () => {
   const decision = decideOrdinaryTurn({
     turn: turn([{ role: "user", content: "hello" }]),

--- a/tests/contract/ordinary-turn-decide.test.ts
+++ b/tests/contract/ordinary-turn-decide.test.ts
@@ -39,6 +39,7 @@ function completedRecord(first: ReturnType<typeof turn>, assistant = "first") {
     parentAssistantAnchor: first.lineage.parentAssistantAnchor,
     turnIndex: first.lineage.turnIndex,
     toolCatalogDigest: first.lineage.toolCatalogDigest,
+    sessionPolicyFingerprint: first.lineage.sessionPolicyFingerprint,
     assistantAnchor,
     agentId: "agent-1",
     credentialFingerprint: TENANT,
@@ -140,4 +141,27 @@ test("disabled coordinator always rebuilds", () => {
     hasReplay: false,
   });
   expect(decision).toEqual({ action: "rebuild", reason: "coordinator_disabled" });
+});
+
+test("ordinary successor rebuilds when the stored policy fingerprint is absent or changed", () => {
+  const first = turn([{ role: "user", content: "hello" }]);
+  const follow = turn([
+    { role: "user", content: "hello" },
+    { role: "assistant", content: "first" },
+    { role: "user", content: "next" },
+  ]);
+  for (const sessionPolicyFingerprint of [undefined, "a".repeat(64)]) {
+    const store = makeJournal();
+    store.upsert({ ...completedRecord(first), sessionPolicyFingerprint });
+    expect(
+      decideOrdinaryTurn({
+        turn: follow,
+        journal: store,
+        inflight: new Set(),
+        now: 10,
+        enabled: true,
+        hasReplay: false,
+      }),
+    ).toMatchObject({ action: "rebuild", reason: "lineage_mismatch" });
+  }
 });

--- a/tests/contract/session-policy.test.ts
+++ b/tests/contract/session-policy.test.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "vitest";
+import {
+  sessionPolicyFingerprint,
+  type SessionPolicyInput,
+} from "../../src/core/session-policy.js";
+import type { AnthropicTool } from "../../src/protocols/anthropic/types.js";
+
+const baseTool: AnthropicTool = {
+  name: "lookup",
+  sdk_name: "mcp__exa__lookup",
+  tool_kind: "function",
+  namespace: "mcp__exa",
+  description: "Look up a value",
+  input_schema: {
+    type: "object",
+    properties: {
+      q: { type: "string", description: "query" },
+      limit: { type: "integer" },
+    },
+    required: ["q"],
+  },
+};
+
+const secondTool: AnthropicTool = {
+  name: "fetch",
+  description: "Fetch a value",
+  input_schema: { type: "object", properties: { id: { type: "string" } } },
+};
+
+const base: SessionPolicyInput = {
+  modelId: "composer-2.5",
+  modelParams: [
+    { id: "effort", value: "high" },
+    { id: "fast", value: "false" },
+  ],
+  tools: [baseTool, secondTool],
+  toolChoice: { mode: "named" as const, name: "mcp__exa__lookup", disableParallel: true },
+};
+
+test("session policy is stable across object keys, model params, and tool order", () => {
+  const reordered = {
+    ...base,
+    modelParams: [...base.modelParams].reverse(),
+    tools: [
+      secondTool,
+      {
+        ...baseTool,
+        input_schema: {
+          required: ["q"],
+          properties: {
+            limit: { type: "integer" },
+            q: { description: "query", type: "string" },
+          },
+          type: "object",
+        },
+      },
+    ],
+  };
+  expect(sessionPolicyFingerprint(reordered)).toBe(sessionPolicyFingerprint(base));
+});
+
+const changes: Array<[string, Partial<SessionPolicyInput>]> = [
+  ["model id", { modelId: "grok-4.6" }],
+  ["model params", { modelParams: [{ id: "effort", value: "low" }] }],
+  ["public tool name", { tools: [{ ...baseTool, name: "search" }, secondTool] }],
+  ["SDK tool name", { tools: [{ ...baseTool, sdk_name: "mcp__exa__search" }, secondTool] }],
+  ["tool kind", { tools: [{ ...baseTool, tool_kind: "custom" }, secondTool] }],
+  ["namespace", { tools: [{ ...baseTool, namespace: "mcp__other" }, secondTool] }],
+  ["description", { tools: [{ ...baseTool, description: "Different" }, secondTool] }],
+  [
+    "schema",
+    {
+      tools: [
+        {
+          ...baseTool,
+          input_schema: { type: "object", properties: { q: { type: "number" } } },
+        },
+        secondTool,
+      ],
+    },
+  ],
+  ["choice policy", { toolChoice: { mode: "auto" as const, disableParallel: false } }],
+];
+
+test.each(changes)("session policy changes with %s", (_label, change) => {
+  expect(sessionPolicyFingerprint({ ...base, ...change })).not.toBe(sessionPolicyFingerprint(base));
+});

--- a/tests/fixtures/fake-sdk.ts
+++ b/tests/fixtures/fake-sdk.ts
@@ -21,6 +21,7 @@ import {
 export type FakeStep =
   | { type: "text"; chunks: string[]; pauseBetweenMs?: number; early?: boolean }
   | { type: "thinking"; chunks: string[]; early?: boolean }
+  | { type: "send-tools"; calls: Array<{ name: string; input: Record<string, unknown>; id?: string }> }
   | { type: "tools"; calls: Array<{ name: string; input: Record<string, unknown>; id?: string; delayMs?: number }> }
   | { type: "silent-final"; text: string }
   | { type: "empty" }
@@ -276,6 +277,17 @@ export class FakeAgent implements SdkAgent {
       earlyCount,
     );
     this.runs.push(run);
+    if (first?.type === "send-tools") {
+      for (const call of first.calls) {
+        const tool = (sendInput.customTools ?? this.input.customTools)[call.name];
+        if (!tool) throw new Error(`fake sdk missing tool ${call.name}`);
+        void Promise.resolve(
+          tool.execute(call.input, { toolCallId: call.id ?? `sdk_${randomUUID()}` }),
+        ).then((result) => {
+          run.capturedToolResults.push(result);
+        });
+      }
+    }
     if (earlyCount > 0 && first && (first.type === "text" || first.type === "thinking")) {
       const kind = first.type === "thinking" ? "thinking-delta" : "text-delta";
       for (const chunk of first.chunks) {

--- a/tests/fixtures/fake-sdk.ts
+++ b/tests/fixtures/fake-sdk.ts
@@ -324,7 +324,7 @@ export class FakeSdk implements SdkRuntime {
   readonly credentialProbeCalls: string[] = [];
 
   constructor(private readonly options: FakeSdkOptions = {}) {
-    this.sdkVersion = options.sdkVersion ?? "1.0.28";
+    this.sdkVersion = options.sdkVersion ?? "1.0.30";
     this.models = options.models ?? {
       ok: true,
       models: [{ id: "composer-2.5", displayName: "Composer 2.5" }],

--- a/tests/fixtures/fake-sdk.ts
+++ b/tests/fixtures/fake-sdk.ts
@@ -44,6 +44,8 @@ export interface FakeSdkOptions {
   createErrorsByApiKey?: Record<string, { message: string; name?: string } | Array<{ message: string; name?: string }>>;
   credentialProbeByApiKey?: Record<string, "valid" | "invalid" | "unavailable">;
   resumeError?: { message: string; name?: string };
+  /** Invoke these custom tools synchronously inside resumeAgent(), before the Agent is returned. */
+  resumeEarlyToolCalls?: Array<{ name: string; input: Record<string, unknown>; id?: string }>;
 }
 
 function configuredError(input: { message: string; name?: string }): Error {
@@ -371,6 +373,13 @@ export class FakeSdk implements SdkRuntime {
     this.lastResume = input;
     this.resumeCalls.push(input);
     this.lastAllowlist = apiProfileToolAllowlist(input.clientToolNames);
+    for (const call of this.options.resumeEarlyToolCalls ?? []) {
+      const tool = input.customTools[call.name];
+      if (!tool) throw new Error(`fake sdk missing resume tool ${call.name}`);
+      void Promise.resolve(
+        tool.execute(call.input, { toolCallId: call.id ?? `sdk_${randomUUID()}` }),
+      ).catch(() => undefined);
+    }
     const agent = new FakeAgent(
       input,
       this.takeScripts([[{ type: "text", chunks: ["resumed"] }]]),

--- a/tests/integration/capacity.test.ts
+++ b/tests/integration/capacity.test.ts
@@ -225,11 +225,18 @@ test("drain rejects completed follow-up but still accepts awaiting tool_result",
 test("adopt refuses to replace a different live session", async () => {
   const ctx = await startTestApp();
   apps.push(ctx);
-  const live = ctx.app.registry.create({ credentialFingerprint: "fp", modelId: "composer-2.5" });
+  const live = ctx.app.registry.create({
+    credentialFingerprint: "fp",
+    modelId: "composer-2.5",
+    sessionPolicyFingerprint: "a".repeat(64),
+    executableToolCatalogFingerprint: "b".repeat(64),
+  });
   const other = new Session({
     sessionId: live.sessionId,
     credentialFingerprint: "fp",
     modelId: "composer-2.5",
+    sessionPolicyFingerprint: "a".repeat(64),
+    executableToolCatalogFingerprint: "b".repeat(64),
     instanceId: ctx.app.registry.instanceId,
     clock: ctx.clock,
   });

--- a/tests/integration/lineage.test.ts
+++ b/tests/integration/lineage.test.ts
@@ -245,11 +245,13 @@ test("lineage files are owner-only and expire", async () => {
   const stateDir = mkdtempSync(join(tmpdir(), "cursor-sdk2api-lineage-"));
   const store = new LineageStore(stateDir, clock);
   store.put({
-    version: 1,
+    version: 2,
     sessionId: "ses_perm",
     sdkAgentId: "agent-1",
     credentialFingerprint: "fp",
     modelId: "composer-2.5",
+    sessionPolicyFingerprint: "a".repeat(64),
+    executableToolCatalogFingerprint: "b".repeat(64),
     state: "completed",
     pendingToolIds: [],
     createdAt: 5_000,

--- a/tests/integration/lineage.test.ts
+++ b/tests/integration/lineage.test.ts
@@ -80,6 +80,57 @@ test("completed follow-up after process restart resumes the SDK agent", async ()
   expect(app2.sdk.lastCreate).toBeUndefined();
 });
 
+test("completed lineage resume preserves a tool callback fired inside resumeAgent", async () => {
+  const stateDir = mkdtempSync(join(tmpdir(), "cursor-sdk2api-lineage-"));
+  const app1 = await startTestApp({
+    config: { stateDir },
+    sdk: { scripts: [[{ type: "text", chunks: ["first"] }]] },
+  });
+  apps.push(app1);
+  const first = await api(app1, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "hello" }],
+      tools: [weatherTool()],
+    }),
+  });
+  const sessionId = ((await first.json()) as { cursor_session_id: string }).cursor_session_id;
+  await closeTestApp(app1);
+  apps.pop();
+
+  const app2 = await startTestApp({
+    config: { stateDir, firstEventTimeoutMs: 25 },
+    sdk: {
+      scripts: [[{ type: "hang" }]],
+      resumeEarlyToolCalls: [
+        { name: "lookup", input: { q: "weather" }, id: "completed_lineage_early" },
+      ],
+    },
+  });
+  apps.push(app2);
+  const follow = await api(app2, "/v1/messages", {
+    method: "POST",
+    headers: { "x-cursor-session-id": sessionId },
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "use the tool" }],
+      tools: [weatherTool()],
+    }),
+  });
+  const body = (await follow.json()) as { content: Array<{ type: string; id?: string; name?: string }> };
+
+  expect(follow.status).toBe(200);
+  expect(body.content).toContainEqual(expect.objectContaining({
+    type: "tool_use",
+    id: "completed_lineage_early",
+    name: "lookup",
+  }));
+  expect(app2.sdk.lastResume?.customTools).toBe(app2.sdk.agents[0]?.lastSend?.customTools);
+});
+
 test("lineage follow-up rejects credential and model mismatch", async () => {
   const stateDir = mkdtempSync(join(tmpdir(), "cursor-sdk2api-lineage-"));
   const app1 = await startTestApp({

--- a/tests/integration/lineage.test.ts
+++ b/tests/integration/lineage.test.ts
@@ -365,6 +365,6 @@ test("lineage expiry blocks follow-up after TTL", async () => {
 test("createCursorRuntime opens JsonlLocalAgentStore under STATE_DIR", () => {
   const stateDir = mkdtempSync(join(tmpdir(), "cursor-sdk2api-sdk-store-"));
   const runtime = createCursorRuntime({ stateDir });
-  expect(runtime.sdkVersion).toMatch(/1\.0\./);
+  expect(runtime.sdkVersion).toBe("1.0.30");
   expect(existsSync(join(stateDir, "sdk-store"))).toBe(true);
 });

--- a/tests/integration/ordinary-turn-coordinator.test.ts
+++ b/tests/integration/ordinary-turn-coordinator.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, expect, test } from "vitest";
 import { FakeClock } from "../../src/clock.js";
-import { api, closeTestApp, startTestApp, type TestContext } from "../helpers/app.js";
+import { api, closeTestApp, startTestApp, weatherTool, type TestContext } from "../helpers/app.js";
 
 let ctx: TestContext;
 
@@ -52,6 +52,46 @@ test("exact ordinary next turn reuses one Agent and sends only current text", as
   expect(ctx.sdk.agents[0]?.runs).toHaveLength(2);
   expect(ctx.sdk.agents[0]?.lastSend?.text).toBe("next");
   expect(ctx.sdk.agents[0]?.lastSend?.text).not.toContain("hello");
+});
+
+test("reused Agent publishes a tool called synchronously during follow-up send", async () => {
+  ctx = await startTestApp({
+    config: { firstEventTimeoutMs: 25 },
+    sdk: {
+      scripts: [
+        [{ type: "text", chunks: ["first"] }],
+        [
+          { type: "send-tools", calls: [{ name: "lookup", input: { q: "weather" }, id: "early_followup" }] },
+          { type: "hang" },
+        ],
+      ],
+    },
+  });
+  const first = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "hello" }],
+      tools: [weatherTool()],
+    }),
+  });
+  const firstBody = (await first.json()) as { content: Array<{ text?: string }> };
+
+  const follow = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify(followBody(firstBody.content[0]?.text ?? "first", "use the tool", {
+      tools: [weatherTool()],
+    })),
+  });
+  const body = (await follow.json()) as { content: Array<{ type: string; id?: string; name?: string }> };
+
+  expect(follow.status).toBe(200);
+  expect(body.content).toContainEqual(expect.objectContaining({
+    type: "tool_use",
+    id: "early_followup",
+    name: "lookup",
+  }));
 });
 
 test("feature flag off keeps a cold rebuild for every ordinary turn", async () => {

--- a/tests/integration/ordinary-turn-coordinator.test.ts
+++ b/tests/integration/ordinary-turn-coordinator.test.ts
@@ -143,6 +143,38 @@ test("identical request digest replays without a second SDK send", async () => {
   );
 });
 
+test("same user text under a different system prompt never replays the old response", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      agentScripts: [
+        [[{ type: "text", chunks: ["from-system-a"] }]],
+        [[{ type: "text", chunks: ["from-system-b"] }]],
+      ],
+    },
+  });
+  const body = (system: string) => ({
+    model: "composer-2.5",
+    max_tokens: 16,
+    system,
+    messages: [{ role: "user", content: "same user text" }],
+  });
+
+  const first = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify(body("system A")),
+  });
+  expect(first.status).toBe(200);
+
+  const second = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify(body("system B")),
+  });
+  const secondBody = (await second.json()) as { content: Array<{ text?: string }> };
+  expect(second.status).toBe(200);
+  expect(secondBody.content[0]?.text).toBe("from-system-b");
+  expect(ctx.sdk.createCalls).toHaveLength(2);
+});
+
 test("an earlier ordinary turn replays its own response after a later turn completes", async () => {
   ctx = await startTestApp({
     sdk: {

--- a/tests/integration/ordinary-turn-coordinator.test.ts
+++ b/tests/integration/ordinary-turn-coordinator.test.ts
@@ -209,6 +209,75 @@ test("an earlier ordinary turn replays its own response after a later turn compl
   expect(ctx.sdk.agents[0]?.runs).toHaveLength(2);
 });
 
+test("an ordinary tool request replays its original tool_use after its continuation completes", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      scripts: [[
+        { type: "tools", calls: [{ name: "lookup", input: { q: "weather" }, id: "initial_tool" }] },
+        { type: "text", chunks: ["sunny"] },
+      ]],
+    },
+  });
+  const initialPayload = {
+    model: "composer-2.5",
+    max_tokens: 16,
+    messages: [{ role: "user", content: "weather?" }],
+    tools: [weatherTool()],
+  };
+  const initial = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify(initialPayload),
+  });
+  const initialBody = (await initial.json()) as {
+    content: Array<{ type: string; id?: string; name?: string }>;
+    stop_reason: string;
+  };
+  expect(initial.status).toBe(200);
+  expect(initialBody.stop_reason).toBe("tool_use");
+  expect(initialBody.content).toContainEqual(expect.objectContaining({
+    type: "tool_use",
+    id: "initial_tool",
+    name: "lookup",
+  }));
+
+  const continued = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify({
+      ...initialPayload,
+      messages: [
+        ...initialPayload.messages,
+        { role: "assistant", content: initialBody.content },
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "initial_tool", content: "72F" }],
+        },
+      ],
+    }),
+  });
+  const continuedBody = (await continued.json()) as {
+    content: Array<{ type: string; text?: string }>;
+    stop_reason: string;
+  };
+  expect(continued.status).toBe(200);
+  expect(continuedBody.stop_reason).toBe("end_turn");
+  expect(continuedBody.content).toContainEqual(expect.objectContaining({ type: "text", text: "sunny" }));
+
+  const replay = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify(initialPayload),
+  });
+  const replayBody = (await replay.json()) as {
+    content: Array<{ type: string; id?: string; name?: string; text?: string }>;
+    stop_reason: string;
+  };
+  expect(replay.status).toBe(200);
+  expect(replayBody.stop_reason).toBe("tool_use");
+  expect(replayBody.content).toEqual(initialBody.content);
+  expect(replayBody.content).not.toContainEqual(expect.objectContaining({ type: "text", text: "sunny" }));
+  expect(ctx.sdk.createCalls).toHaveLength(1);
+  expect(ctx.sdk.agents[0]?.runs).toHaveLength(1);
+});
+
 test("expired ordinary replay is released and the same request runs again", async () => {
   const clock = new FakeClock(1_000);
   ctx = await startTestApp({

--- a/tests/integration/ordinary-turn-coordinator.test.ts
+++ b/tests/integration/ordinary-turn-coordinator.test.ts
@@ -468,6 +468,48 @@ test("process restart resumes the persisted Agent and sends only the current tur
   expect(ctx.sdk.agents[0]?.lastSend?.text).toBe("next");
 });
 
+test("persisted ordinary resume preserves a tool callback fired inside resumeAgent", async () => {
+  const stateDir = mkdtempSync(join(tmpdir(), "cursor-sdk2api-ordinary-"));
+  const firstApp = await startTestApp({
+    config: { stateDir },
+    sdk: { scripts: [[{ type: "text", chunks: ["first"] }]] },
+  });
+  const first = await api(firstApp, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "hello" }],
+      tools: [weatherTool()],
+    }),
+  });
+  const assistant = ((await first.json()) as { content: Array<{ text?: string }> }).content[0]?.text ?? "first";
+  await closeTestApp(firstApp);
+
+  ctx = await startTestApp({
+    config: { stateDir, firstEventTimeoutMs: 25 },
+    sdk: {
+      scripts: [[{ type: "hang" }]],
+      resumeEarlyToolCalls: [
+        { name: "lookup", input: { q: "weather" }, id: "persisted_ordinary_early" },
+      ],
+    },
+  });
+  const follow = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify(followBody(assistant, "use the tool", { tools: [weatherTool()] })),
+  });
+  const body = (await follow.json()) as { content: Array<{ type: string; id?: string; name?: string }> };
+
+  expect(follow.status).toBe(200);
+  expect(body.content).toContainEqual(expect.objectContaining({
+    type: "tool_use",
+    id: "persisted_ordinary_early",
+    name: "lookup",
+  }));
+  expect(ctx.sdk.lastResume?.customTools).toBe(ctx.sdk.agents[0]?.lastSend?.customTools);
+});
+
 test("Responses exact successor sends only the current turn", async () => {
   ctx = await startTestApp({
     sdk: {

--- a/tests/integration/ordinary-turn-coordinator.test.ts
+++ b/tests/integration/ordinary-turn-coordinator.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, expect, test } from "vitest";
+import { FakeClock } from "../../src/clock.js";
 import { api, closeTestApp, startTestApp, type TestContext } from "../helpers/app.js";
 
 let ctx: TestContext;
@@ -100,6 +101,79 @@ test("identical request digest replays without a second SDK send", async () => {
   expect(((await a.json()) as { content: unknown }).content).toEqual(
     ((await later.json()) as { content: unknown }).content,
   );
+});
+
+test("an earlier ordinary turn replays its own response after a later turn completes", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      scripts: [[{ type: "text", chunks: ["first"] }], [{ type: "text", chunks: ["second"] }]],
+    },
+  });
+  const firstPayload = {
+    model: "composer-2.5",
+    max_tokens: 16,
+    messages: [{ role: "user", content: "hello" }],
+  };
+  const first = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify(firstPayload),
+  });
+  const firstBody = (await first.json()) as { content: Array<{ text?: string }> };
+
+  const follow = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify(followBody(firstBody.content[0]?.text ?? "first")),
+  });
+  expect(follow.status).toBe(200);
+
+  const replay = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify(firstPayload),
+  });
+  const replayBody = (await replay.json()) as { content: Array<{ text?: string }> };
+  expect(replay.status).toBe(200);
+  expect(replayBody.content[0]?.text).toBe("first");
+  expect(ctx.sdk.createCalls).toHaveLength(1);
+  expect(ctx.sdk.agents[0]?.runs).toHaveLength(2);
+});
+
+test("expired ordinary replay is released and the same request runs again", async () => {
+  const clock = new FakeClock(1_000);
+  ctx = await startTestApp({
+    clock,
+    config: { sessionTtlMs: 1_000, sweepIntervalMs: 5 },
+    sdk: {
+      agentScripts: [
+        [[{ type: "text", chunks: ["first"] }]],
+        [[{ type: "text", chunks: ["rebuilt"] }]],
+      ],
+    },
+  });
+  const payload = {
+    model: "composer-2.5",
+    max_tokens: 16,
+    messages: [{ role: "user", content: "expire me" }],
+  };
+  const first = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+  expect(first.status).toBe(200);
+  expect(ctx.app.coordinator.ordinaryReplayCount()).toBe(1);
+
+  clock.advance(1_001);
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  expect(ctx.app.coordinator.ordinaryReplayCount()).toBe(0);
+  expect(ctx.sdk.agents[0]?.closed).toBe(true);
+
+  const retried = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+  const retriedBody = (await retried.json()) as { content: Array<{ text?: string }> };
+  expect(retried.status).toBe(200);
+  expect(retriedBody.content[0]?.text).toBe("rebuilt");
+  expect(ctx.sdk.createCalls).toHaveLength(2);
 });
 
 test("a forked successor cold-rebuilds without sending on the original Agent", async () => {

--- a/tests/integration/ordinary-turn-coordinator.test.ts
+++ b/tests/integration/ordinary-turn-coordinator.test.ts
@@ -54,6 +54,54 @@ test("exact ordinary next turn reuses one Agent and sends only current text", as
   expect(ctx.sdk.agents[0]?.lastSend?.text).not.toContain("hello");
 });
 
+test("an explicit session follow-up never seeds headerless ordinary replay", async () => {
+  ctx = await startTestApp({
+    sdk: {
+      agentScripts: [
+        [
+          [{ type: "text", chunks: ["first"] }],
+          [{ type: "text", chunks: ["contextual"] }],
+        ],
+        [[{ type: "text", chunks: ["fresh"] }]],
+      ],
+    },
+  });
+  const first = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "hello" }],
+    }),
+  });
+  expect(first.status).toBe(200);
+  const sessionId = first.headers.get("x-cursor-session-id");
+  expect(sessionId).toMatch(/^ses_/);
+
+  const minimal = {
+    model: "composer-2.5",
+    max_tokens: 16,
+    messages: [{ role: "user", content: "same" }],
+  };
+  const contextual = await api(ctx, "/v1/messages", {
+    method: "POST",
+    headers: { "x-cursor-session-id": sessionId as string },
+    body: JSON.stringify(minimal),
+  });
+  const contextualBody = (await contextual.json()) as { content: Array<{ text?: string }> };
+  expect(contextual.status).toBe(200);
+  expect(contextualBody.content[0]?.text).toBe("contextual");
+
+  const headerless = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify(minimal),
+  });
+  const headerlessBody = (await headerless.json()) as { content: Array<{ text?: string }> };
+  expect(headerless.status).toBe(200);
+  expect(headerlessBody.content[0]?.text).toBe("fresh");
+  expect(ctx.sdk.createCalls).toHaveLength(2);
+});
+
 test("reused Agent publishes a tool called synchronously during follow-up send", async () => {
   ctx = await startTestApp({
     config: { firstEventTimeoutMs: 25 },

--- a/tests/integration/session-policy-resume.test.ts
+++ b/tests/integration/session-policy-resume.test.ts
@@ -1,0 +1,243 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test } from "vitest";
+import {
+  api,
+  closeTestApp,
+  openaiWeatherTool,
+  responsesWeatherTool,
+  startTestApp,
+  weatherTool,
+  type TestContext,
+} from "../helpers/app.js";
+
+const apps: TestContext[] = [];
+
+afterEach(async () => {
+  while (apps.length > 0) {
+    const app = apps.pop();
+    if (app) await closeTestApp(app);
+  }
+});
+
+test("Messages, Chat, and Responses share one equivalent executable session policy", async () => {
+  const ctx = await startTestApp({
+    sdk: {
+      scripts: [
+        [{ type: "text", chunks: ["messages"] }],
+        [{ type: "text", chunks: ["chat"] }],
+        [{ type: "text", chunks: ["responses"] }],
+      ],
+    },
+  });
+  apps.push(ctx);
+
+  const first = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "first" }],
+      tools: [weatherTool()],
+    }),
+  });
+  const sessionId = first.headers.get("x-cursor-session-id");
+  expect(first.status).toBe(200);
+  expect(sessionId).toMatch(/^ses_/);
+
+  const chatTool = openaiWeatherTool();
+  chatTool.function.parameters = {
+    required: ["q"],
+    properties: { q: { type: "string" } },
+    type: "object",
+  };
+  const chat = await api(ctx, "/v1/chat/completions", {
+    method: "POST",
+    headers: { "x-cursor-session-id": sessionId as string },
+    body: JSON.stringify({
+      model: "composer-2.5",
+      messages: [{ role: "user", content: "second" }],
+      tools: [chatTool],
+    }),
+  });
+  expect(chat.status).toBe(200);
+
+  const responses = await api(ctx, "/v1/responses", {
+    method: "POST",
+    headers: { "x-cursor-session-id": sessionId as string },
+    body: JSON.stringify({
+      model: "composer-2.5",
+      input: "third",
+      tools: [responsesWeatherTool()],
+    }),
+  });
+  expect(responses.status).toBe(200);
+  expect(ctx.sdk.createCalls).toHaveLength(1);
+  expect(ctx.sdk.agents[0]?.runs).toHaveLength(3);
+});
+
+test.each([
+  ["Messages", "/v1/messages", (tool: ReturnType<typeof weatherTool>) => ({
+    model: "composer-2.5",
+    max_tokens: 16,
+    messages: [{ role: "user", content: "next" }],
+    tools: [tool],
+  })],
+  ["Chat", "/v1/chat/completions", (tool: ReturnType<typeof weatherTool>) => ({
+    model: "composer-2.5",
+    messages: [{ role: "user", content: "next" }],
+    tools: [{ type: "function", function: { name: tool.name, description: tool.description, parameters: tool.input_schema } }],
+  })],
+  ["Responses", "/v1/responses", (tool: ReturnType<typeof weatherTool>) => ({
+    model: "composer-2.5",
+    input: "next",
+    tools: [{ type: "function", name: tool.name, description: tool.description, parameters: tool.input_schema }],
+  })],
+])("%s explicit follow-up rejects a changed tool schema", async (_name, path, body) => {
+  const ctx = await startTestApp({
+    sdk: { scripts: [[{ type: "text", chunks: ["first"] }], [{ type: "text", chunks: ["unsafe"] }]] },
+  });
+  apps.push(ctx);
+  const first = await api(ctx, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "first" }],
+      tools: [weatherTool()],
+    }),
+  });
+  const sessionId = first.headers.get("x-cursor-session-id") as string;
+  const changed = weatherTool();
+  changed.input_schema.properties.q.type = "number";
+  const follow = await api(ctx, path, {
+    method: "POST",
+    headers: { "x-cursor-session-id": sessionId },
+    body: JSON.stringify(body(changed)),
+  });
+  expect(follow.status).toBe(409);
+  expect(ctx.sdk.agents[0]?.runs).toHaveLength(1);
+});
+
+test("explicit follow-up rejects changed model parameters and namespace", async () => {
+  const ctx = await startTestApp({ sdk: { scripts: [[{ type: "text", chunks: ["first"] }]] } });
+  apps.push(ctx);
+  const namespaceTool = (namespace: string) => ({
+    type: "namespace",
+    name: namespace,
+    tools: [{
+      type: "function",
+      name: "search",
+      description: "Search",
+      parameters: { type: "object", properties: { q: { type: "string" } } },
+    }],
+  });
+  const first = await api(ctx, "/v1/responses", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "grok-4.6",
+      reasoning: { effort: "high" },
+      input: [{ type: "additional_tools", tools: [namespaceTool("mcp__exa")] }, { type: "message", role: "user", content: "first" }],
+    }),
+  });
+  const sessionId = first.headers.get("x-cursor-session-id") as string;
+
+  const changedParams = await api(ctx, "/v1/responses", {
+    method: "POST",
+    headers: { "x-cursor-session-id": sessionId },
+    body: JSON.stringify({
+      model: "grok-4.6",
+      reasoning: { effort: "low" },
+      input: [{ type: "additional_tools", tools: [namespaceTool("mcp__exa")] }, { type: "message", role: "user", content: "next" }],
+    }),
+  });
+  expect(changedParams.status).toBe(409);
+
+  const changedNamespace = await api(ctx, "/v1/responses", {
+    method: "POST",
+    headers: { "x-cursor-session-id": sessionId },
+    body: JSON.stringify({
+      model: "grok-4.6",
+      reasoning: { effort: "high" },
+      input: [{ type: "additional_tools", tools: [namespaceTool("mcp__other")] }, { type: "message", role: "user", content: "next" }],
+    }),
+  });
+  expect(changedNamespace.status).toBe(409);
+  expect(ctx.sdk.agents[0]?.runs).toHaveLength(1);
+});
+
+test("pending lineage rejects a changed catalog before resume or transcript recovery", async () => {
+  const stateDir = mkdtempSync(join(tmpdir(), "cursor-sdk2api-policy-pending-"));
+  const firstApp = await startTestApp({
+    config: { stateDir },
+    sdk: { scripts: [[{ type: "tools", calls: [{ name: "lookup", input: { q: "x" }, id: "call_policy" }] }]] },
+  });
+  apps.push(firstApp);
+  const first = await api(firstApp, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "go" }],
+      tools: [weatherTool()],
+    }),
+  });
+  expect(first.status).toBe(200);
+  await closeTestApp(firstApp);
+  apps.pop();
+
+  const secondApp = await startTestApp({ config: { stateDir } });
+  apps.push(secondApp);
+  const changed = weatherTool();
+  changed.description = "Changed execution contract";
+  const resumed = await api(secondApp, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: [{ type: "tool_result", tool_use_id: "call_policy", content: "ok" }] }],
+      tools: [changed],
+    }),
+  });
+  expect(resumed.status).toBe(409);
+  expect(secondApp.sdk.resumeCalls).toHaveLength(0);
+  expect(secondApp.sdk.createCalls).toHaveLength(0);
+});
+
+test("legacy lineage without a policy fingerprint cannot resume", async () => {
+  const stateDir = mkdtempSync(join(tmpdir(), "cursor-sdk2api-policy-legacy-"));
+  const firstApp = await startTestApp({ config: { stateDir } });
+  apps.push(firstApp);
+  const first = await api(firstApp, "/v1/messages", {
+    method: "POST",
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "first" }],
+    }),
+  });
+  const sessionId = first.headers.get("x-cursor-session-id") as string;
+  await closeTestApp(firstApp);
+  apps.pop();
+
+  const lineagePath = join(stateDir, "lineage", `${sessionId}.json`);
+  const legacy = JSON.parse(readFileSync(lineagePath, "utf8")) as Record<string, unknown>;
+  legacy.version = 1;
+  delete legacy.sessionPolicyFingerprint;
+  writeFileSync(lineagePath, JSON.stringify(legacy), "utf8");
+
+  const secondApp = await startTestApp({ config: { stateDir } });
+  apps.push(secondApp);
+  const follow = await api(secondApp, "/v1/messages", {
+    method: "POST",
+    headers: { "x-cursor-session-id": sessionId },
+    body: JSON.stringify({
+      model: "composer-2.5",
+      max_tokens: 16,
+      messages: [{ role: "user", content: "next" }],
+    }),
+  });
+  expect(follow.status).toBe(409);
+  expect(secondApp.sdk.resumeCalls).toHaveLength(0);
+});


### PR DESCRIPTION
## Summary

- centralize official Cursor SDK create/resume/send and early callback delivery in one `SdkRunDriver`
- bind resume/replay to canonical model, tool catalog, namespace, schema, system, and history identities
- make ordinary replay snapshots immutable, TTL-bounded, and isolated from explicit session follow-ups
- upgrade the exact official `@cursor/sdk` pin to `1.0.30`
- prepare `v0.3.1`

## Verification

- 33 test files / 236 tests passed
- server + web typecheck passed
- server + console build passed
- git diff check passed
- release-range secret scan found no leaks
- independent final structural review: PASS, no P1/P2/P3

## Release boundaries

- lineage schema v1 records fail closed and are quarantined after upgrade
- live Cursor credential matrix is not part of this deterministic PR gate
- hosted search/compaction and BeefAPI billing/control-plane code are intentionally not included
